### PR TITLE
[S2-QA-01] Add test cases TC-001 to TC-005 — documents expected behav…

### DIFF
--- a/docs/test-cases/TC-001.md
+++ b/docs/test-cases/TC-001.md
@@ -1,0 +1,47 @@
+# TC-001: User Registration via Supabase Auth
+
+**Project:** Student Mental Health & Wellness Tracker
+**Sprint:** S2 — Design (Weeks 2–3)
+**Issue ID:** S2-QA-01
+**Prepared by:** Kimmoguer | M5 — QA / Docs Lead
+**Date Prepared:** April 20, 2026
+**Status:** Pending Execution (Feature Not Yet Built)
+
+---
+
+| Field | Details |
+|---|---|
+| **Test Case ID** | TC-001 |
+| **Related Issues** | S3-DEV-01 |
+| **Feature Under Test** | Supabase Auth — Sign Up |
+| **Preconditions** | App is running locally (`npm run dev`). Supabase project is live. `.env.local` contains valid `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY`. |
+| **Test Type** | Functional |
+
+---
+
+## Test Steps
+
+1. Navigate to the Sign Up page.
+2. Enter a valid, previously unregistered email address (e.g., `testuser@email.com`).
+3. Enter a valid password that meets minimum requirements (e.g., at least 6 characters).
+4. Click the **Sign Up** / **Register** button.
+5. Check the Supabase Dashboard → Authentication → Users for the new entry.
+
+---
+
+## Expected Result
+
+- User is successfully created in `auth.users` table in Supabase.
+- User is redirected to the Dashboard or a confirmation screen.
+- No error message is displayed.
+
+---
+
+## Results
+
+| Field | Value |
+|---|---|
+| **Actual Result** | _(To be filled upon execution)_ |
+| **Pass / Fail** | _(Pending)_ |
+| **Tested By** | Kimmoguer |
+| **Date Executed** | _(To be filled)_ |

--- a/docs/test-cases/TC-002.md
+++ b/docs/test-cases/TC-002.md
@@ -1,0 +1,47 @@
+# TC-002: User Login via Supabase Auth
+
+**Project:** Student Mental Health & Wellness Tracker
+**Sprint:** S2 — Design (Weeks 2–3)
+**Issue ID:** S2-QA-01
+**Prepared by:** Kimmoguer | M5 — QA / Docs Lead
+**Date Prepared:** April 20, 2026
+**Status:** Pending Execution (Feature Not Yet Built)
+
+---
+
+| Field | Details |
+|---|---|
+| **Test Case ID** | TC-002 |
+| **Related Issues** | S3-DEV-01 |
+| **Feature Under Test** | Supabase Auth — Login & Session Persistence |
+| **Preconditions** | TC-001 has been executed successfully. The registered test account exists. |
+| **Test Type** | Functional |
+
+---
+
+## Test Steps
+
+1. Navigate to the Login page.
+2. Enter the registered email and correct password from TC-001.
+3. Click the **Log In** button.
+4. Close the browser tab and reopen the app.
+5. Observe whether the session is still active (user remains logged in).
+
+---
+
+## Expected Result
+
+- User is successfully authenticated and redirected to the Dashboard.
+- Session persists after the browser tab is closed and reopened (session persistence is active).
+- No error or "invalid credentials" message appears.
+
+---
+
+## Results
+
+| Field | Value |
+|---|---|
+| **Actual Result** | _(To be filled upon execution)_ |
+| **Pass / Fail** | _(Pending)_ |
+| **Tested By** | Kimmoguer |
+| **Date Executed** | _(To be filled)_ |

--- a/docs/test-cases/TC-003.md
+++ b/docs/test-cases/TC-003.md
@@ -1,0 +1,47 @@
+# TC-003: Supabase Row Level Security (RLS) — Data Isolation Between Users
+
+**Project:** Student Mental Health & Wellness Tracker  
+**Sprint:** S2 — Design (Weeks 2–3)  
+**Issue ID:** S2-QA-01  
+**Prepared by:** Kimmoguer | M5 — QA / Docs Lead  
+**Date Prepared:** April 20, 2026  
+**Status:** Pending Execution (Feature Not Yet Built)
+
+---
+
+| Field | Details |
+|---|---|
+| **Test Case ID** | TC-003 |
+| **Related Issues** | S2-DEV-02, S3-DEV-02 |
+| **Feature Under Test** | Supabase RLS Policies — Users can only access their own data |
+| **Preconditions** | Two separate test accounts exist (e.g., `user_a@test.com`, `user_b@test.com`). Mood logging feature is built. RLS is enabled on the `mood_logs` table with policy: `auth.uid() = user_id`. |
+| **Test Type** | Security / Functional |
+
+---
+
+## Test Steps
+
+1. Log in as `user_a` and submit a mood log entry (e.g., mood score: 7, note: "Feeling okay").
+2. Log out.
+3. Log in as `user_b`.
+4. Navigate to the mood log list or Dashboard.
+5. Observe whether `user_b` can see `user_a`'s mood log entry.
+
+---
+
+## Expected Result
+
+- `user_b` sees **only their own** mood log entries.
+- `user_a`'s entry is **not visible** to `user_b`.
+- No 403 or unauthorized error is thrown — the data is simply absent from the query result.
+
+---
+
+## Results
+
+| Field | Value |
+|---|---|
+| **Actual Result** | _(To be filled upon execution)_ |
+| **Pass / Fail** | _(Pending)_ |
+| **Tested By** | Kimmoguer |
+| **Date Executed** | _(To be filled)_ |

--- a/docs/test-cases/TC-004.md
+++ b/docs/test-cases/TC-004.md
@@ -1,0 +1,66 @@
+# TC-004: Stressor Tag Assignment on Journal Entry (KM Taxonomy — Externalization Phase)
+
+**Project:** Student Mental Health & Wellness Tracker  
+**Sprint:** S2 — Design (Weeks 2–3)  
+**Issue ID:** S2-QA-01  
+**Prepared by:** Kimmoguer | M5 — QA / Docs Lead  
+**Date Prepared:** April 20, 2026  
+**Status:** Pending Execution (Feature Not Yet Built)
+
+---
+
+| Field | Details |
+|---|---|
+| **Test Case ID** | TC-004 |
+| **Related Issues** | S3-DEV-03, S2-KM-01 |
+| **Feature Under Test** | Journal Entry — Tag field using KM Knowledge Taxonomy |
+| **KM Reference** | `km-architecture.md` §2.1 Stressors and Triggers (Externalization Phase); §2.2 Coping & Behavioral Responses (Combination Phase) |
+| **Preconditions** | User is logged in. Journal entry form is accessible. Tag taxonomy from `km-architecture.md` is implemented in the database (`journal_entries.tags` as `text[]`). |
+| **Test Type** | Functional / KM Alignment |
+
+---
+
+## KM Background
+
+The SECI **Externalization Phase** requires that students convert tacit, unspoken distress into explicit, measurable units via stressor tags. The taxonomy in `km-architecture.md` §2.1 defines tags across five broad categories:
+
+| Category | Example Tags |
+|---|---|
+| Academic | `#WorkOverload`, `#TestStress`, `#EvaluationStage` |
+| Social | `#PeerStress`, `#PerformanceAnxiety` |
+| Institutional | `#Isolation`, `#TransitionAdaptation` |
+| Personal | `#SelfExpectation`, `#Perfectionism` |
+| Digital | `#InformationOverload`, `#TimeManagement` |
+
+Section §2.2 further defines Coping & Behavioral Response tags (e.g., `#Venting`, `#ActiveCoping`) for the **Combination Phase**. The journal entry form must allow assignment of both tag types so that fragmented self-knowledge becomes structured, retrievable data.
+
+---
+
+## Test Steps
+
+1. Navigate to the Journal / Reflection screen.
+2. Enter a title (e.g., "Rough week before finals") and a body text.
+3. In the tag selector, assign at least two tags from different taxonomy categories — e.g., `#TestStress` (Academic) and `#Venting` (Emotion-Centered Coping).
+4. Click **Save** / **Submit**.
+5. Open the saved journal entry and verify the tags are displayed.
+6. Check the Supabase Dashboard → `journal_entries` table and confirm the `tags` column stores the correct values.
+
+---
+
+## Expected Result
+
+- The journal entry is saved with both tags stored in the `tags` (`text[]`) column in Supabase.
+- Tags are displayed correctly when the saved entry is opened.
+- Tag values match the taxonomy defined in `km-architecture.md` (e.g., stored as `#TestStress`, not `teststress` or `Test Stress`).
+- No error is thrown during saving.
+
+---
+
+## Results
+
+| Field | Value |
+|---|---|
+| **Actual Result** | _(To be filled upon execution)_ |
+| **Pass / Fail** | _(Pending)_ |
+| **Tested By** | Kimmoguer |
+| **Date Executed** | _(To be filled)_ |

--- a/docs/test-cases/TC-005.md
+++ b/docs/test-cases/TC-005.md
@@ -1,0 +1,61 @@
+# TC-005: Tag-Based Retrieval / Filtering of Journal Entries (KM Retrieval Requirement)
+
+**Project:** Student Mental Health & Wellness Tracker  
+**Sprint:** S2 — Design (Weeks 2–3)  
+**Issue ID:** S2-QA-01  
+**Prepared by:** Kimmoguer | M5 — QA / Docs Lead  
+**Date Prepared:** April 20, 2026  
+**Status:** Pending Execution (Feature Not Yet Built)
+
+---
+
+| Field | Details |
+|---|---|
+| **Test Case ID** | TC-005 |
+| **Related Issues** | S4-DEV-02, S2-KM-01, S2-KM-02 |
+| **Feature Under Test** | Search & Retrieve — Tag-Based Filtering of Journal Entries |
+| **KM Reference** | `km-architecture.md` §3 Retrieval Requirements, Item 1: "The system must allow users to query logs by specific stressor tags (e.g., 'Show all entries tagged #TestStress')." |
+| **Preconditions** | User is logged in. At least three journal entries exist with different tag combinations — Entry A tagged `#TestStress`, Entry B tagged `#PeerStress`, Entry C tagged `#TestStress` and `#Perfectionism`. |
+| **Test Type** | Functional / KM Alignment |
+
+---
+
+## KM Background
+
+The **Combination** and **Internalization** phases of the SECI Model require that users can retrieve and synthesize their previously externalized data. `km-architecture.md` §3 Retrieval Requirement #1 mandates tag-based filtering so students can surface patterns — for example, viewing all entries associated with `#TestStress` to recognize a recurring academic stressor.
+
+Without this feature, the app fails its core KM objective stated in Retrieval Requirement #3: *"The retrieval design must allow the student to identify latent triggers, such as how `#PeerStress` might correlate with diminished sleep quality."* Tag filtering is the foundation that makes pattern identification possible.
+
+---
+
+## Test Steps
+
+1. Navigate to the Search / Retrieve screen.
+2. Select or type the tag `#TestStress` in the tag filter input.
+3. Trigger the search / apply the filter.
+4. Observe the results list.
+5. Verify that **only** entries tagged with `#TestStress` are shown (Entry A and Entry C — not Entry B).
+6. Clear the filter and apply `#PeerStress` instead.
+7. Verify only Entry B appears.
+
+---
+
+## Expected Result
+
+- Filtering by `#TestStress` returns exactly Entry A and Entry C.
+- Filtering by `#PeerStress` returns exactly Entry B.
+- Results do not include entries from other users (RLS is respected — see TC-003).
+- The filter responds within a reasonable time (under 3 seconds).
+- Clearing the filter restores the full list of the user's entries.
+
+---
+
+## Results
+
+| Field | Value |
+|---|---|
+| **Actual Result** | _(To be filled upon execution)_ |
+| **Pass / Fail** | _(Pending)_ |
+| **Tested By** | Kimmoguer |
+| **Date Executed** | _(To be filled)_ |
+    


### PR DESCRIPTION
## Summary
Closes / Addresses: **S2-QA-01**

This PR adds the Sprint 2 QA deliverable: five test cases documenting the expected behavior of the app's planned core features, filed in `/docs/test-cases/`.

---

## Changes Made

### Files Added
- `docs/test-cases/TC-001-to-TC-005.md`

### Test Cases Included

| TC ID | Feature Under Test | KM Reference |
|---|---|---|
| TC-001 | User Registration via Supabase Auth | — |
| TC-002 | User Login & Session Persistence | — |
| TC-003 | RLS Data Isolation Between Users | S2-DEV-02 |
| TC-004 | Stressor Tag Assignment on Journal Entry | km-architecture.md §2.1–2.2 |
| TC-005 | Tag-Based Retrieval / Filtering | km-architecture.md §3 Retrieval Req. #1 |

---

## KM Alignment Note
TC-004 and TC-005 are directly derived from `km-architecture.md` written by the KM Analyst.  
- **TC-004** tests the Externalization Phase of the SECI Model — converting tacit distress into structured stressor tags.  
- **TC-005** tests Retrieval Requirement #1 — tag-based filtering that enables the Combination and Internalization phases.

---

## Checklist
- [x] Test cases filed in `/docs/test-cases/`
- [x] TC IDs follow project convention (TC-001 format)
- [x] Related Issue IDs cross-referenced in each test case
- [x] TC-004 and TC-005 cite km-architecture.md
- [x] No secrets or `.env` files committed
- [x] Branch is `feature/qa-docs`, targeting `dev`

---

**Reviewed by:** _(PM to approve)_  
**Ready to merge:** After 1 approval