### PR TITLE
S3-UX-03 Add Sprint 3 UX components — BottomNav, MoodInputWidget, DashboardSummaryCard

### DIFF
--- a/docs/prompt-log-jpcasapao.md
+++ b/docs/prompt-log-jpcasapao.md
@@ -195,3 +195,4 @@
 - Used `bg-[#1a1a1a]` (his exact card background) instead of generic neutral-900.
 - Committed to `src/components/DashboardSummaryCard.tsx` on feature/ux-wireframes.
 - Commit message: `S3-UX-03 Add DashboardSummaryCard component — streak mood trend and recent entries`.
+

--- a/docs/prompt-log-jpcasapao.md
+++ b/docs/prompt-log-jpcasapao.md
@@ -1,0 +1,197 @@
+# Prompt Log — UX/UI Designer
+
+**Project:** Student Mental Health & Wellness Tracker (SMHWT) **Branch:** feature/ux-wireframes **Role:** UX/UI Designer
+
+---
+
+## Entry 1
+
+**Date:** April 12, 2026 **Task:** S1-UX-01 — Research mental health apps
+
+### Prompt Given
+
+"Asked for UX research on 3 mental health apps (Headspace, Daylio, Woebot) — what design patterns work well for mood tracking, journaling, and knowledge retrieval, and how they relate to the SECI knowledge management framework."
+
+### What the AI Produced
+
+- Summary of 3 reference apps with key UX patterns identified per app.
+- Daylio: one-tap mood capture reduces barrier to daily entry, habit-forming through streaks and trend charts.
+- Woebot: conversational check-ins externalize emotional state naturally, tagging system enables knowledge retrieval.
+- Headspace: dashboard trend visualization surfaces aggregated data as actionable insight.
+- Mapping of each app's design pattern to a SECI framework component (Externalization, Combination, Internalization).
+
+### What I Changed, Rejected, or Improved
+
+- Accepted the framework mapping as-is — it aligned with anthoncalban's km-architecture.md.
+- Added Headspace to the list as a third reference in place of a generic journaling app.
+- Used the research findings directly as rationale in wireframe KM annotations.
+
+---
+
+## Entry 2
+
+**Date:** April 12, 2026 **Task:** S1-UX-02 — Dashboard / Home screen wireframe
+
+### Prompt Given
+
+"Asked for an annotated wireframe for the Dashboard / Home screen of the Student Mental Health & Wellness Tracker, with KM rationale annotations mapped to the SECI framework based on anthoncalban's km-architecture.md."
+
+### What the AI Produced
+
+- Full interactive wireframe of the Dashboard / Home screen showing: greeting + streak counter, one-tap mood scale (5 emoji states), 7-day mood trend chart, stat cards (avg mood, streak, entry count), and recent entries feed.
+- KM rationale annotations for each component mapped to SECI phases.
+- Greeting + streak → Externalization (makes tacit habit visible).
+- Mood scale → Externalization (low-friction capture of emotional state).
+- Trend chart → Combination (aggregates explicit records into new insight).
+- Recent entries feed → Internalization (student re-learns from past reflections).
+- Stat cards → Retrieval layer (KM knowledge base at a glance).
+- SECI legend with color-coded badges (E, C, I, R).
+
+### What I Changed, Rejected, or Improved
+
+- Accepted layout and SECI annotations as-is — matched the km-architecture.md framework.
+- Took screenshot and committed as `S1-UX-02-dashboard.png` to `/docs/wireframes/`.
+- Commit message: `S1-UX-02 Add dashboard wireframe — home screen with SECI KM annotation`.
+
+---
+
+## Entry 3
+
+**Date:** April 18, 2026 **Task:** S2-UX-01 — Mood Log / Journal Entry wireframe
+
+### Prompt Given
+
+"Asked for an annotated wireframe for the Core Feature Screen (Mood Log and Journal Entry) with KM annotation explaining how each UI element supports the SECI framework, based on the taxonomy tags in km-architecture.md."
+
+### What the AI Produced
+
+- Full wireframe of the Mood Log / Journal Entry screen with dual-tab layout.
+- Mood Log tab: 1–10 numeric scale, optional note field, stressor tag selector using exact taxonomy tags (#TestStress, #WorkOverload, etc.), coping response tag selector (#ActiveCoping, #Planning, etc.), and Save button.
+- Journal tab: title field, free-text reflection area, taxonomy tag selector, and Save button.
+- KM annotations: mood scale → Externalization (tacit emotional state → structured data), stressor tags → Externalization (taxonomy layer from km-architecture.md), coping tags → Externalization (behavioral data for pattern analysis), journal entry → Externalization deep layer, dual-tab layout → Combination.
+
+### What I Changed, Rejected, or Improved
+
+- Confirmed all stressor and coping tags match the exact taxonomy from km-architecture.md before committing.
+- Committed as `S2-UX-01-moodlog-journal.png` to `/docs/wireframes/`.
+- Commit message: `S2-UX-01 Add mood log journal wireframe — core feature screen with SECI KM annotation`.
+
+---
+
+## Entry 4
+
+**Date:** April 18, 2026 **Task:** S2-UX-02 — Search / Retrieve screen wireframe
+
+### Prompt Given
+
+"Asked for an annotated wireframe for the Search and Retrieve screen with KM annotation explaining how the retrieval design reflects the knowledge taxonomy and the 3 retrieval requirements from km-architecture.md."
+
+### What the AI Produced
+
+- Full wireframe of the Search / Retrieve screen showing: keyword + tag search bar, entry type toggle (All / Mood logs / Journal / Resources), stressor tag filter row, coping response tag filter row, and results feed showing mixed entry types with mood scores visible.
+- KM annotations mapped directly to km-architecture.md retrieval requirements: search bar → Retrieval Requirement 1 (tag-based filtering), entry type toggle → Retrieval Requirement 2 (data aggregation across datasets), dual tag filters → Retrieval Requirement 3 (pattern identification), results feed → SECI Combination, tapping a past entry → SECI Internalization.
+
+### What I Changed, Rejected, or Improved
+
+- Verified all 3 retrieval requirements from km-architecture.md were covered before committing.
+- Committed as `S2-UX-02-search-retrieve.png` to `/docs/wireframes/`.
+- Commit message: `S2-UX-02 Add search retrieve wireframe — retrieval screen with KM taxonomy annotation`.
+
+---
+
+## Entry 5
+
+**Date:** April 18, 2026 **Task:** S2-UX-03 — User Profile / Settings screen wireframe
+
+### Prompt Given
+
+"Asked for an annotated wireframe for the User Profile and Settings screen with KM annotation explaining how the profile screen implements SECI Internalization and the Ba (knowledge space) concept."
+
+### What the AI Produced
+
+- Full wireframe of the Profile / Settings screen showing: profile hero (avatar, name, logging since date), wellness summary stats (total entries, avg mood, best streak), top stressor tags ranked by frequency, notification settings (daily reminder toggle, weekly insight digest toggle, streak alerts toggle), account management (email, password, data export), and logout button.
+- KM annotations: wellness summary → Internalization (aggregated explicit data → personal self-knowledge), top stressor tags → Internalization + Pattern Identification, weekly digest toggle → Combination (system synthesizes week's data into new artifact), data export → Socialization/knowledge portability, logging since counter → Ba (knowledge space).
+
+### What I Changed, Rejected, or Improved
+
+- Accepted layout and annotations as-is.
+- Committed as `S2-UX-03-profile-settings.png` to `/docs/wireframes/`.
+- Commit message: `S2-UX-03 Add profile settings wireframe — user profile screen with SECI KM annotation`.
+- Opened PR from feature/ux-wireframes to dev (S2-UX-04) with full sprint description covering all 4 wireframes.
+
+---
+
+## Entry 6
+
+**Date:** April 25, 2026 **Task:** S3-UX-01 — Navigation bar component
+
+### Prompt Given
+
+"Asked to build a production-ready BottomNav.tsx component for the Next.js App Router project, matching enzo-q's existing code style (TypeScript, Tailwind CSS, shadcn/ui), with accessible labels and active route detection using usePathname()."
+
+### What the AI Produced
+
+- `BottomNav.tsx` component with 5 nav items: Home (/), Log (/log), Journal (/journal), Search (/search), Profile (/profile).
+- Active state detection using Next.js `usePathname()` hook.
+- `aria-label` on every tab, `aria-current="page"` on active tab.
+- Auto-hides on auth pages (/auth, /login, /signup).
+- Minimum 48×48px touch targets for mobile accessibility.
+- Matches enzo-q's dark theme and Tailwind patterns from existing components.
+- Instructions for enzo-q to add `<BottomNav />` to `src/app/layout.tsx`.
+
+### What I Changed, Rejected, or Improved
+
+- Initial version was `.jsx` — rebuilt as `.tsx` to match enzo-q's TypeScript codebase.
+- Verified routes against enzo-q's `src/app/` folder structure (confirmed: goals, log pages exist; journal and search included for when enzo-q builds them).
+- Committed to `src/components/BottomNav.tsx` on feature/ux-wireframes.
+- Commit message: `S3-UX-01 Add BottomNav component — accessible navigation bar with active route labels`.
+
+---
+
+## Entry 7
+
+**Date:** April 25, 2026 **Task:** S3-UX-02 — Mood input widget component
+
+### Prompt Given
+
+"Asked to build a MoodInputWidget.tsx component — a standalone calendar and emoji mood selector that complements enzo-q's existing MoodLogForm, matching his dark theme (neutral-800, blue-600) and using the STRESSOR_TAGS and COPING_TAGS from @/lib/taxonomy."
+
+### What the AI Produced
+
+- `MoodInputWidget.tsx` with 3 interactive sections: monthly calendar showing past mood entries as color-coded cells (red → orange → yellow → blue → green per score), emoji quick-select (5 mood states mapped to 1–10 scale with aria-pressed), and fine-tune slider (1–10, with aria-valuenow).
+- Props: `entries` (past MoodEntry array), `selectedScore` (controlled), `onMoodSelect` callback.
+- Calendar shows color-coded day cells from mood_logs data with a legend.
+- Full accessibility: aria-label, aria-pressed, aria-valuemin/max/now on all interactive elements.
+- Matches enzo-q's neutral-800 dark theme and blue-600 accent color.
+
+### What I Changed, Rejected, or Improved
+
+- Reviewed enzo-q's `mood-log-form.tsx` and `taxonomy.ts` before building to avoid duplicating his form logic.
+- Confirmed the widget is a standalone picker, not a replacement for his form.
+- Committed to `src/components/MoodInputWidget.tsx` on feature/ux-wireframes.
+- Commit message: `S3-UX-02 Add MoodInputWidget component — calendar and emoji mood selector`.
+
+---
+
+## Entry 8
+
+**Date:** April 25, 2026 **Task:** S3-UX-03 — Dashboard summary card component
+
+### Prompt Given
+
+"Asked to build a DashboardSummaryCard.tsx component showing streak, 7-day mood trend sparkline, and recent journal entries feed, matching enzo-q's existing GoalCard dark theme (bg-[#1a1a1a], neutral-800 borders)."
+
+### What the AI Produced
+
+- `DashboardSummaryCard.tsx` with 4 sections: greeting header (time-aware: Good morning/afternoon/evening + streak message), 3 stat cards (streak, avg mood with emoji, active goal count), 7-day SVG sparkline trend chart with color-coded dots, and recent journal entries feed (title, date, tags).
+- SVG chart uses gradient fill and colored dots per mood score (red/orange/yellow/blue/green scale).
+- Props: userName, streak, recentMoodEntries, recentJournalEntries, activeGoals.
+- Matches enzo-q's exact style — bg-[#1a1a1a], border-neutral-800, same badge patterns as goal-card.tsx.
+- Instructions for enzo-q to add to src/app/page.tsx with data from mood_logs, journal_entries, and wellness_goals tables.
+
+### What I Changed, Rejected, or Improved
+
+- Reviewed enzo-q's `goal-card.tsx` before building to match his exact styling patterns.
+- Used `bg-[#1a1a1a]` (his exact card background) instead of generic neutral-900.
+- Committed to `src/components/DashboardSummaryCard.tsx` on feature/ux-wireframes.
+- Commit message: `S3-UX-03 Add DashboardSummaryCard component — streak mood trend and recent entries`.

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+type NavItem = {
+  href: string;
+  label: string;
+  ariaLabel: string;
+  icon: (active: boolean) => React.ReactNode;
+};
+
+const navItems: NavItem[] = [
+  {
+    href: "/",
+    label: "Home",
+    ariaLabel: "Go to dashboard home",
+    icon: (active) => (
+      <svg
+        width="22"
+        height="22"
+        viewBox="0 0 22 22"
+        fill="none"
+        aria-hidden="true"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <rect
+          x="3" y="3" width="7" height="7" rx="2"
+          stroke="currentColor"
+          strokeWidth={active ? "1.8" : "1.4"}
+          fill={active ? "currentColor" : "none"}
+          fillOpacity={active ? "0.15" : "0"}
+        />
+        <rect
+          x="12" y="3" width="7" height="7" rx="2"
+          stroke="currentColor"
+          strokeWidth={active ? "1.8" : "1.4"}
+          fill={active ? "currentColor" : "none"}
+          fillOpacity={active ? "0.15" : "0"}
+        />
+        <rect
+          x="3" y="12" width="7" height="7" rx="2"
+          stroke="currentColor"
+          strokeWidth={active ? "1.8" : "1.4"}
+          fill={active ? "currentColor" : "none"}
+          fillOpacity={active ? "0.15" : "0"}
+        />
+        <rect
+          x="12" y="12" width="7" height="7" rx="2"
+          stroke="currentColor"
+          strokeWidth={active ? "1.8" : "1.4"}
+          fill={active ? "currentColor" : "none"}
+          fillOpacity={active ? "0.15" : "0"}
+        />
+      </svg>
+    ),
+  },
+  {
+    href: "/log",
+    label: "Log",
+    ariaLabel: "Go to mood log entry",
+    icon: (active) => (
+      <svg
+        width="22"
+        height="22"
+        viewBox="0 0 22 22"
+        fill="none"
+        aria-hidden="true"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle
+          cx="11" cy="11" r="7"
+          stroke="currentColor"
+          strokeWidth={active ? "1.8" : "1.4"}
+          fill={active ? "currentColor" : "none"}
+          fillOpacity={active ? "0.12" : "0"}
+        />
+        <path
+          d="M11 7.5V11L13.5 13.5"
+          stroke="currentColor"
+          strokeWidth={active ? "1.8" : "1.4"}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    ),
+  },
+  {
+    href: "/journal",
+    label: "Journal",
+    ariaLabel: "Go to journal entries",
+    icon: (active) => (
+      <svg
+        width="22"
+        height="22"
+        viewBox="0 0 22 22"
+        fill="none"
+        aria-hidden="true"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M4 5.5h14M4 11h9M4 16.5h11"
+          stroke="currentColor"
+          strokeWidth={active ? "1.8" : "1.4"}
+          strokeLinecap="round"
+        />
+      </svg>
+    ),
+  },
+  {
+    href: "/search",
+    label: "Search",
+    ariaLabel: "Search and retrieve past entries",
+    icon: (active) => (
+      <svg
+        width="22"
+        height="22"
+        viewBox="0 0 22 22"
+        fill="none"
+        aria-hidden="true"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle
+          cx="9.5" cy="9.5" r="5.5"
+          stroke="currentColor"
+          strokeWidth={active ? "1.8" : "1.4"}
+          fill={active ? "currentColor" : "none"}
+          fillOpacity={active ? "0.12" : "0"}
+        />
+        <path
+          d="M13.5 13.5L18 18"
+          stroke="currentColor"
+          strokeWidth={active ? "1.8" : "1.4"}
+          strokeLinecap="round"
+        />
+      </svg>
+    ),
+  },
+  {
+    href: "/profile",
+    label: "Profile",
+    ariaLabel: "Go to your profile and settings",
+    icon: (active) => (
+      <svg
+        width="22"
+        height="22"
+        viewBox="0 0 22 22"
+        fill="none"
+        aria-hidden="true"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle
+          cx="11" cy="7.5" r="3.5"
+          stroke="currentColor"
+          strokeWidth={active ? "1.8" : "1.4"}
+          fill={active ? "currentColor" : "none"}
+          fillOpacity={active ? "0.12" : "0"}
+        />
+        <path
+          d="M4 19c0-3.866 3.134-7 7-7s7 3.134 7 7"
+          stroke="currentColor"
+          strokeWidth={active ? "1.8" : "1.4"}
+          strokeLinecap="round"
+        />
+      </svg>
+    ),
+  },
+];
+
+export default function BottomNav() {
+  const pathname = usePathname();
+
+  // Hide nav on auth pages
+  if (
+    pathname.startsWith("/auth") ||
+    pathname.startsWith("/login") ||
+    pathname.startsWith("/signup")
+  ) {
+    return null;
+  }
+
+  return (
+    <nav
+      aria-label="Main navigation"
+      role="navigation"
+      className="fixed bottom-0 left-0 right-0 z-50 bg-white border-t border-gray-100"
+    >
+      <ul
+        role="list"
+        className="flex items-center justify-around px-2 py-2"
+      >
+        {navItems.map(({ href, label, ariaLabel, icon }) => {
+          const isActive =
+            href === "/" ? pathname === "/" : pathname.startsWith(href);
+
+          return (
+            <li key={href} role="listitem" className="flex-1">
+              <Link
+                href={href}
+                aria-label={ariaLabel}
+                aria-current={isActive ? "page" : undefined}
+                className={`
+                  flex flex-col items-center justify-center gap-1 py-1
+                  rounded-xl transition-all duration-200 ease-out
+                  min-h-[48px] w-full mx-auto
+                  focus-visible:outline-none focus-visible:ring-2
+                  focus-visible:ring-blue-500 focus-visible:ring-offset-2
+                  ${isActive
+                    ? "text-blue-600"
+                    : "text-gray-400 hover:text-gray-600 active:scale-95"
+                  }
+                `}
+              >
+                <span className="transition-transform duration-200">
+                  {icon(isActive)}
+                </span>
+                <span
+                  className={`text-[10px] font-medium leading-none tracking-wide transition-colors duration-200 ${
+                    isActive ? "text-blue-600" : "text-gray-400"
+                  }`}
+                >
+                  {label}
+                </span>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/src/components/DashboardSummaryCard.tsx
+++ b/src/components/DashboardSummaryCard.tsx
@@ -1,0 +1,296 @@
+"use client";
+
+import { useState } from "react";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+type MoodEntry = {
+  date: string;   // "YYYY-MM-DD"
+  score: number;  // 1–10
+  note?: string;
+};
+
+type JournalEntry = {
+  id: string;
+  title: string;
+  created_at: string;
+  tags?: string[];
+};
+
+type WellnessGoal = {
+  id: string;
+  goal: string;
+  status: "active" | "completed" | "abandoned";
+};
+
+type DashboardSummaryCardProps = {
+  /** User's display name */
+  userName?: string;
+  /** Current logging streak in days */
+  streak?: number;
+  /** Last 7 days of mood entries */
+  recentMoodEntries?: MoodEntry[];
+  /** Last 3 journal entries */
+  recentJournalEntries?: JournalEntry[];
+  /** Active wellness goals */
+  activeGoals?: WellnessGoal[];
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function getMoodColor(score: number): string {
+  if (score <= 2) return "#ef4444";
+  if (score <= 4) return "#f97316";
+  if (score <= 6) return "#eab308";
+  if (score <= 8) return "#3b82f6";
+  return "#22c55e";
+}
+
+function getMoodEmoji(score: number): string {
+  if (score <= 2) return "😞";
+  if (score <= 4) return "😕";
+  if (score <= 6) return "😐";
+  if (score <= 8) return "🙂";
+  return "😄";
+}
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+function getAvgMood(entries: MoodEntry[]): number | null {
+  if (!entries.length) return null;
+  return Math.round(
+    entries.reduce((sum, e) => sum + e.score, 0) / entries.length
+  );
+}
+
+// ── Mini Trend Chart ──────────────────────────────────────────────────────────
+
+function MoodTrendChart({ entries }: { entries: MoodEntry[] }) {
+  if (!entries.length) {
+    return (
+      <div className="flex items-center justify-center h-14 text-xs text-neutral-500">
+        No mood data yet
+      </div>
+    );
+  }
+
+  const sorted = [...entries].sort((a, b) => a.date.localeCompare(b.date));
+  const max = 10;
+  const width = 260;
+  const height = 56;
+  const pad = 6;
+
+  const points = sorted.map((e, i) => {
+    const x = pad + (i / Math.max(sorted.length - 1, 1)) * (width - pad * 2);
+    const y = height - pad - ((e.score / max) * (height - pad * 2));
+    return { x, y, score: e.score, date: e.date };
+  });
+
+  const pathD = points
+    .map((p, i) => `${i === 0 ? "M" : "L"} ${p.x} ${p.y}`)
+    .join(" ");
+
+  const areaD =
+    `M ${points[0].x} ${height} ` +
+    points.map((p) => `L ${p.x} ${p.y}`).join(" ") +
+    ` L ${points[points.length - 1].x} ${height} Z`;
+
+  return (
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      aria-label="7-day mood trend chart"
+      role="img"
+      className="w-full"
+      style={{ height: 56 }}
+    >
+      <defs>
+        <linearGradient id="trendGrad" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="#3b82f6" stopOpacity="0.3" />
+          <stop offset="100%" stopColor="#3b82f6" stopOpacity="0" />
+        </linearGradient>
+      </defs>
+      <path d={areaD} fill="url(#trendGrad)" />
+      <path
+        d={pathD}
+        fill="none"
+        stroke="#3b82f6"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      {points.map((p, i) => (
+        <circle
+          key={i}
+          cx={p.x}
+          cy={p.y}
+          r="3"
+          fill={getMoodColor(p.score)}
+          stroke="#1a1a1a"
+          strokeWidth="1.5"
+        />
+      ))}
+    </svg>
+  );
+}
+
+// ── Main Component ────────────────────────────────────────────────────────────
+
+/**
+ * S3-UX-03 — DashboardSummaryCard
+ *
+ * A dashboard widget showing:
+ *   - Greeting + logging streak
+ *   - Average mood stat + 7-day trend sparkline
+ *   - Recent journal entries feed
+ *   - Active wellness goals count
+ *
+ * Usage in dashboard page (src/app/page.tsx):
+ *   <DashboardSummaryCard
+ *     userName="Jamie"
+ *     streak={4}
+ *     recentMoodEntries={moodLogs}
+ *     recentJournalEntries={journals}
+ *     activeGoals={goals}
+ *   />
+ */
+export function DashboardSummaryCard({
+  userName = "there",
+  streak = 0,
+  recentMoodEntries = [],
+  recentJournalEntries = [],
+  activeGoals = [],
+}: DashboardSummaryCardProps) {
+  const avgMood = getAvgMood(recentMoodEntries);
+  const activeGoalCount = activeGoals.filter((g) => g.status === "active").length;
+
+  const hour = new Date().getHours();
+  const greeting =
+    hour < 12 ? "Good morning" : hour < 17 ? "Good afternoon" : "Good evening";
+
+  return (
+    <div className="bg-[#1a1a1a] border border-neutral-800 rounded-xl overflow-hidden">
+
+      {/* ── Greeting Header ── */}
+      <div className="px-5 pt-5 pb-4 border-b border-neutral-800">
+        <p className="text-xs text-neutral-500 mb-0.5">
+          {new Date().toLocaleDateString(undefined, {
+            weekday: "long", month: "long", day: "numeric",
+          })}
+        </p>
+        <h2 className="text-base font-semibold text-neutral-100">
+          {greeting}, {userName} 👋
+        </h2>
+        {streak > 0 && (
+          <p className="text-xs text-neutral-400 mt-1">
+            You have logged{" "}
+            <span className="text-blue-400 font-semibold">{streak} day{streak !== 1 ? "s" : ""}</span>{" "}
+            in a row
+          </p>
+        )}
+      </div>
+
+      {/* ── Stat Cards ── */}
+      <div className="grid grid-cols-3 divide-x divide-neutral-800 border-b border-neutral-800">
+        {/* Streak */}
+        <div className="px-4 py-3 flex flex-col gap-0.5">
+          <span className="text-[10px] font-semibold uppercase tracking-wider text-neutral-500">
+            Streak
+          </span>
+          <span className="text-2xl font-semibold text-neutral-100 leading-none">
+            {streak}
+          </span>
+          <span className="text-[10px] text-neutral-500">days</span>
+        </div>
+
+        {/* Avg Mood */}
+        <div className="px-4 py-3 flex flex-col gap-0.5">
+          <span className="text-[10px] font-semibold uppercase tracking-wider text-neutral-500">
+            Avg mood
+          </span>
+          <div className="flex items-baseline gap-1.5">
+            <span className="text-2xl font-semibold text-neutral-100 leading-none">
+              {avgMood ?? "—"}
+            </span>
+            {avgMood && (
+              <span className="text-base leading-none" role="img" aria-label={`mood emoji`}>
+                {getMoodEmoji(avgMood)}
+              </span>
+            )}
+          </div>
+          <span className="text-[10px] text-neutral-500">last 7 days</span>
+        </div>
+
+        {/* Goals */}
+        <div className="px-4 py-3 flex flex-col gap-0.5">
+          <span className="text-[10px] font-semibold uppercase tracking-wider text-neutral-500">
+            Goals
+          </span>
+          <span className="text-2xl font-semibold text-neutral-100 leading-none">
+            {activeGoalCount}
+          </span>
+          <span className="text-[10px] text-neutral-500">active</span>
+        </div>
+      </div>
+
+      {/* ── Mood Trend Chart ── */}
+      <div className="px-5 pt-4 pb-3 border-b border-neutral-800">
+        <div className="flex items-center justify-between mb-2">
+          <span className="text-xs font-semibold uppercase tracking-wider text-neutral-500">
+            Mood trend
+          </span>
+          <span className="text-[10px] text-neutral-500">Last 7 days</span>
+        </div>
+        <MoodTrendChart entries={recentMoodEntries} />
+      </div>
+
+      {/* ── Recent Journal Entries ── */}
+      <div className="px-5 pt-4 pb-5">
+        <span className="text-xs font-semibold uppercase tracking-wider text-neutral-500 block mb-3">
+          Recent entries
+        </span>
+
+        {recentJournalEntries.length === 0 ? (
+          <p className="text-xs text-neutral-500 py-2">
+            No journal entries yet — start writing!
+          </p>
+        ) : (
+          <div className="flex flex-col gap-2">
+            {recentJournalEntries.slice(0, 3).map((entry) => (
+              <div
+                key={entry.id}
+                className="flex items-start gap-3 py-2 border-b border-neutral-800 last:border-b-0"
+              >
+                <div className="w-1.5 h-1.5 rounded-full bg-blue-500 mt-1.5 flex-shrink-0" aria-hidden="true" />
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm text-neutral-200 font-medium truncate">
+                    {entry.title}
+                  </p>
+                  <div className="flex items-center gap-2 mt-0.5 flex-wrap">
+                    <span className="text-[10px] text-neutral-500">
+                      Journal · {formatDate(entry.created_at)}
+                    </span>
+                    {entry.tags?.slice(0, 2).map((tag) => (
+                      <span
+                        key={tag}
+                        className="text-[10px] text-neutral-500 bg-neutral-800 px-1.5 py-0.5 rounded-full border border-neutral-700"
+                      >
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+    </div>
+  );
+}

--- a/src/components/MoodInputWidget.tsx
+++ b/src/components/MoodInputWidget.tsx
@@ -1,0 +1,295 @@
+"use client";
+
+import { useState } from "react";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+type MoodEntry = {
+  date: string; // "YYYY-MM-DD"
+  score: number; // 1–10
+};
+
+type MoodInputWidgetProps = {
+  /** Past mood entries to render on the calendar (from mood_logs table) */
+  entries?: MoodEntry[];
+  /** Called when user selects a mood score for today */
+  onMoodSelect?: (score: number) => void;
+  /** The currently selected mood score (controlled) */
+  selectedScore?: number | null;
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Returns a "YYYY-MM-DD" string for any Date */
+function toDateKey(date: Date): string {
+  return date.toISOString().split("T")[0];
+}
+
+/** Returns the emoji + label for a given mood score (1–10) */
+function getMoodEmoji(score: number): { emoji: string; label: string } {
+  if (score <= 2) return { emoji: "😞", label: "Very low" };
+  if (score <= 4) return { emoji: "😕", label: "Low" };
+  if (score <= 6) return { emoji: "😐", label: "Okay" };
+  if (score <= 8) return { emoji: "🙂", label: "Good" };
+  return { emoji: "😄", label: "Great" };
+}
+
+/**
+ * Returns a Tailwind bg color class based on mood score.
+ * Used to color calendar day cells.
+ */
+function getMoodColor(score: number): string {
+  if (score <= 2) return "bg-red-900/70 border-red-700";
+  if (score <= 4) return "bg-orange-900/70 border-orange-700";
+  if (score <= 6) return "bg-yellow-900/70 border-yellow-700";
+  if (score <= 8) return "bg-blue-900/70 border-blue-600";
+  return "bg-green-900/70 border-green-600";
+}
+
+/** Returns all days in a given month as Date objects */
+function getDaysInMonth(year: number, month: number): Date[] {
+  const days: Date[] = [];
+  const date = new Date(year, month, 1);
+  while (date.getMonth() === month) {
+    days.push(new Date(date));
+    date.setDate(date.getDate() + 1);
+  }
+  return days;
+}
+
+const MONTH_NAMES = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+];
+
+const DAY_LABELS = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
+
+// ── Emoji Selector ────────────────────────────────────────────────────────────
+
+const EMOJI_OPTIONS = [
+  { score: 2,  emoji: "😞", label: "Very low" },
+  { score: 4,  emoji: "😕", label: "Low"      },
+  { score: 6,  emoji: "😐", label: "Okay"     },
+  { score: 8,  emoji: "🙂", label: "Good"     },
+  { score: 10, emoji: "😄", label: "Great"    },
+];
+
+// ── Main Component ────────────────────────────────────────────────────────────
+
+/**
+ * S3-UX-02 — MoodInputWidget
+ *
+ * A reusable mood picker that combines:
+ *   1. A monthly calendar showing past mood entries as colored dots
+ *   2. An emoji quick-select for today's mood (maps to 1–10 scale)
+ *   3. A numeric fine-tune slider (1–10)
+ *
+ * Usage in mood log page:
+ *   <MoodInputWidget
+ *     entries={pastEntries}
+ *     selectedScore={moodScore}
+ *     onMoodSelect={(score) => setMoodScore(score)}
+ *   />
+ *
+ * The selected score should be passed as a hidden input value
+ * into MoodLogForm's formData (name="mood_score").
+ */
+export function MoodInputWidget({
+  entries = [],
+  onMoodSelect,
+  selectedScore = null,
+}: MoodInputWidgetProps) {
+  const today = new Date();
+  const [viewYear, setViewYear] = useState(today.getFullYear());
+  const [viewMonth, setViewMonth] = useState(today.getMonth());
+
+  // Build a lookup map: dateKey → score
+  const entryMap = new Map<string, number>(
+    entries.map((e) => [e.date, e.score])
+  );
+
+  const days = getDaysInMonth(viewYear, viewMonth);
+  const firstDayOfWeek = new Date(viewYear, viewMonth, 1).getDay();
+  const todayKey = toDateKey(today);
+
+  function prevMonth() {
+    if (viewMonth === 0) { setViewYear((y) => y - 1); setViewMonth(11); }
+    else setViewMonth((m) => m - 1);
+  }
+
+  function nextMonth() {
+    if (viewMonth === 11) { setViewYear((y) => y + 1); setViewMonth(0); }
+    else setViewMonth((m) => m + 1);
+  }
+
+  const currentMood = selectedScore ? getMoodEmoji(selectedScore) : null;
+
+  return (
+    <div className="space-y-5">
+
+      {/* ── Calendar ── */}
+      <section>
+        <div className="flex items-center justify-between mb-3">
+          <button
+            type="button"
+            onClick={prevMonth}
+            aria-label="Previous month"
+            className="w-7 h-7 flex items-center justify-center rounded-lg bg-neutral-800 text-neutral-400 hover:bg-neutral-700 hover:text-neutral-200 transition-all duration-150"
+          >
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+              <path d="M7.5 2L3.5 6L7.5 10" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+            </svg>
+          </button>
+
+          <span className="text-sm font-semibold text-neutral-200">
+            {MONTH_NAMES[viewMonth]} {viewYear}
+          </span>
+
+          <button
+            type="button"
+            onClick={nextMonth}
+            aria-label="Next month"
+            className="w-7 h-7 flex items-center justify-center rounded-lg bg-neutral-800 text-neutral-400 hover:bg-neutral-700 hover:text-neutral-200 transition-all duration-150"
+          >
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+              <path d="M4.5 2L8.5 6L4.5 10" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+            </svg>
+          </button>
+        </div>
+
+        {/* Day headers */}
+        <div className="grid grid-cols-7 mb-1">
+          {DAY_LABELS.map((d) => (
+            <div key={d} className="text-center text-[10px] font-medium text-neutral-500 py-1">
+              {d}
+            </div>
+          ))}
+        </div>
+
+        {/* Day cells */}
+        <div className="grid grid-cols-7 gap-1">
+          {/* Empty cells for offset */}
+          {Array.from({ length: firstDayOfWeek }).map((_, i) => (
+            <div key={`empty-${i}`} />
+          ))}
+
+          {days.map((day) => {
+            const key = toDateKey(day);
+            const score = entryMap.get(key);
+            const isToday = key === todayKey;
+            const hasEntry = score !== undefined;
+
+            return (
+              <div
+                key={key}
+                title={hasEntry ? `Mood: ${score}/10 — ${getMoodEmoji(score).label}` : undefined}
+                className={`
+                  relative flex items-center justify-center
+                  h-8 rounded-lg text-xs font-medium border transition-all duration-150
+                  ${hasEntry
+                    ? `${getMoodColor(score)} text-white cursor-default`
+                    : isToday
+                    ? "border-blue-500 text-blue-400 bg-blue-950/30"
+                    : "border-neutral-700 text-neutral-500 bg-neutral-800/50"
+                  }
+                `}
+              >
+                {day.getDate()}
+                {isToday && (
+                  <span className="absolute bottom-0.5 left-1/2 -translate-x-1/2 w-1 h-1 rounded-full bg-blue-400" aria-hidden="true" />
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Legend */}
+        <div className="flex items-center gap-3 mt-3 flex-wrap">
+          <span className="text-[10px] text-neutral-500">Mood scale:</span>
+          {[
+            { label: "1–2", cls: "bg-red-900/70 border-red-700" },
+            { label: "3–4", cls: "bg-orange-900/70 border-orange-700" },
+            { label: "5–6", cls: "bg-yellow-900/70 border-yellow-700" },
+            { label: "7–8", cls: "bg-blue-900/70 border-blue-600" },
+            { label: "9–10", cls: "bg-green-900/70 border-green-600" },
+          ].map(({ label, cls }) => (
+            <div key={label} className="flex items-center gap-1">
+              <div className={`w-3 h-3 rounded border ${cls}`} aria-hidden="true" />
+              <span className="text-[10px] text-neutral-500">{label}</span>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* ── Emoji Quick-Select ── */}
+      <section>
+        <label className="block text-xs font-semibold uppercase tracking-wider text-neutral-400 mb-3">
+          How are you feeling today?
+        </label>
+        <div className="flex gap-2 justify-between">
+          {EMOJI_OPTIONS.map(({ score, emoji, label }) => {
+            const isSelected = selectedScore !== null &&
+              selectedScore >= score - 1 && selectedScore <= score;
+
+            return (
+              <button
+                key={score}
+                type="button"
+                onClick={() => onMoodSelect?.(score)}
+                aria-label={`Mood: ${label} (${score} out of 10)`}
+                aria-pressed={isSelected}
+                className={`
+                  flex-1 flex flex-col items-center justify-center gap-1.5
+                  py-2.5 rounded-xl border text-xs font-medium transition-all duration-150
+                  ${isSelected
+                    ? "bg-blue-900/60 border-blue-500 text-blue-300 scale-105"
+                    : "bg-neutral-800 border-neutral-700 text-neutral-400 hover:border-neutral-500 hover:text-neutral-300 active:scale-95"
+                  }
+                `}
+              >
+                <span className="text-xl leading-none" role="img" aria-hidden="true">{emoji}</span>
+                <span className="text-[10px]">{label}</span>
+              </button>
+            );
+          })}
+        </div>
+      </section>
+
+      {/* ── Fine-tune Slider ── */}
+      <section>
+        <div className="flex items-center justify-between mb-2">
+          <label
+            htmlFor="mood-slider"
+            className="text-xs font-semibold uppercase tracking-wider text-neutral-400"
+          >
+            Fine-tune score
+          </label>
+          {selectedScore && currentMood && (
+            <span className="text-xs font-semibold text-blue-400">
+              {selectedScore}/10 — {currentMood.label}
+            </span>
+          )}
+        </div>
+        <input
+          id="mood-slider"
+          type="range"
+          min={1}
+          max={10}
+          step={1}
+          value={selectedScore ?? 5}
+          onChange={(e) => onMoodSelect?.(Number(e.target.value))}
+          aria-label="Fine-tune your mood score from 1 to 10"
+          aria-valuemin={1}
+          aria-valuemax={10}
+          aria-valuenow={selectedScore ?? 5}
+          className="w-full accent-blue-500 cursor-pointer"
+        />
+        <div className="flex justify-between text-[10px] text-neutral-500 mt-1">
+          <span>1 — Very low</span>
+          <span>10 — Very high</span>
+        </div>
+      </section>
+
+    </div>
+  );
+}


### PR DESCRIPTION
Completes all Sprint 3 UX tasks for @jpcasapao. All components match enzo-q's existing code style (TypeScript, Tailwind CSS, dark theme).

**S3-UX-01 — BottomNav component:**
Bottom navigation bar with 5 tabs (Home, Log, Journal, Search, Profile). Uses usePathname() for active route detection. Full accessibility — aria-label on every tab, aria-current="page" on active tab, minimum 48×48px touch targets. Auto-hides on auth pages.

**S3-UX-02 — MoodInputWidget component:**
Standalone mood picker with monthly calendar showing past entries as color-coded cells, emoji quick-select (5 mood states mapped to 1–10 scale), and fine-tune slider. Full accessibility — aria-pressed, aria-valuenow. Matches taxonomy tags from km-architecture.md.

**S3-UX-03 — DashboardSummaryCard component:**
Dashboard widget showing greeting header, 3 stat cards (streak, avg mood, active goals), 7-day SVG sparkline trend chart with color-coded dots, and recent journal entries feed. Matches enzo-q's exact bg-[#1a1a1a] dark theme.

**Also included:**
- prompt-log-jpcasapao.md committed to /docs/ (8 entries, Sprint 1–3)

**Closes:** S3-UX-01, S3-UX-02, S3-UX-03