### PR TITLE
S3-UX-02 fix: Bottom Nav Bar, Mood Input Widget

### DIFF
--- a/src/app/log/page.tsx
+++ b/src/app/log/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { MoodLogForm } from "@/components/mood-log-form";
 import { JournalEntryForm } from "@/components/journal-entry-form";
+import { MoodInputWidget } from "@/components/MoodInputWidget";
 import { ChevronLeft } from "lucide-react";
 import Link from "next/link";
 
@@ -27,6 +28,7 @@ function formatDate(date: Date): string {
  */
 export default function LogPage() {
   const [activeTab, setActiveTab] = useState<"mood" | "journal">("mood");
+  const [moodScore, setMoodScore] = useState<number | null>(null);
   const today = formatDate(new Date());
 
   return (
@@ -50,10 +52,9 @@ export default function LogPage() {
           onClick={() => setActiveTab("mood")}
           className={`
             flex-1 py-2 rounded-lg text-sm font-semibold transition-all duration-150
-            ${
-              activeTab === "mood"
-                ? "bg-neutral-950 text-neutral-100 shadow"
-                : "text-neutral-400 hover:text-neutral-200"
+            ${activeTab === "mood"
+              ? "bg-neutral-950 text-neutral-100 shadow"
+              : "text-neutral-400 hover:text-neutral-200"
             }
           `}
         >
@@ -63,10 +64,9 @@ export default function LogPage() {
           onClick={() => setActiveTab("journal")}
           className={`
             flex-1 py-2 rounded-lg text-sm font-semibold transition-all duration-150
-            ${
-              activeTab === "journal"
-                ? "bg-neutral-950 text-neutral-100 shadow"
-                : "text-neutral-400 hover:text-neutral-200"
+            ${activeTab === "journal"
+              ? "bg-neutral-950 text-neutral-100 shadow"
+              : "text-neutral-400 hover:text-neutral-200"
             }
           `}
         >
@@ -75,8 +75,18 @@ export default function LogPage() {
       </div>
 
       {/* ── Form Area ── */}
-      <main className="px-4 pb-32">
-        {activeTab === "mood" ? <MoodLogForm /> : <JournalEntryForm />}
+      <main className="px-4 pb-32 space-y-6">
+        {activeTab === "mood" ? (
+          <>
+            <MoodInputWidget
+              selectedScore={moodScore}
+              onMoodSelect={(score) => setMoodScore(score)}
+            />
+            <MoodLogForm />
+          </>
+        ) : (
+          <JournalEntryForm />
+        )}
       </main>
 
       {/* ── Bottom Nav ── */}
@@ -97,10 +107,9 @@ export default function LogPage() {
             href={href}
             className={`
               text-xs font-medium transition-colors
-              ${
-                href === "/log"
-                  ? "text-blue-400"
-                  : "text-neutral-500 hover:text-neutral-300"
+              ${href === "/log"
+                ? "text-blue-400"
+                : "text-neutral-500 hover:text-neutral-300"
               }
             `}
           >

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -57,7 +57,7 @@ const navItems: NavItem[] = [
   },
   {
     href: "/log",
-    label: "Log",
+    label: "Mood Log",
     ariaLabel: "Go to mood log entry",
     icon: (active) => (
       <svg
@@ -142,9 +142,9 @@ const navItems: NavItem[] = [
     ),
   },
   {
-    href: "/resources",
-    label: "Resources",
-    ariaLabel: "Browse mental health resources",
+    href: "/search",
+    label: "Search",
+    ariaLabel: "Search and retrieve past entries",
     icon: (active) => (
       <svg
         width="22"
@@ -154,21 +154,15 @@ const navItems: NavItem[] = [
         aria-hidden="true"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <rect
-          x="4" y="3" width="9" height="12" rx="2"
+        <circle
+          cx="9.5" cy="9.5" r="5.5"
           stroke="currentColor"
           strokeWidth={active ? "1.8" : "1.4"}
           fill={active ? "currentColor" : "none"}
           fillOpacity={active ? "0.12" : "0"}
         />
         <path
-          d="M7 7h3M7 10h3"
-          stroke="currentColor"
-          strokeWidth={active ? "1.8" : "1.4"}
-          strokeLinecap="round"
-        />
-        <path
-          d="M13 7h2a2 2 0 0 1 2 2v7a2 2 0 0 1-2 2H9a2 2 0 0 1-2-2v-1"
+          d="M13.5 13.5L18 18"
           stroke="currentColor"
           strokeWidth={active ? "1.8" : "1.4"}
           strokeLinecap="round"
@@ -202,7 +196,9 @@ export default function BottomNav() {
       >
         {navItems.map(({ href, label, ariaLabel, icon }) => {
           const isActive =
-            href === "/" ? pathname === "/" : pathname.startsWith(href);
+            href === "/dashboard"
+              ? pathname === "/dashboard"
+              : pathname.startsWith(href);
 
           return (
             <li key={href} role="listitem" className="flex-1">

--- a/src/components/MoodInputWidget.tsx
+++ b/src/components/MoodInputWidget.tsx
@@ -125,171 +125,173 @@ export function MoodInputWidget({
   const currentMood = selectedScore ? getMoodEmoji(selectedScore) : null;
 
   return (
-    <div className="space-y-5">
+    <div className="w-full flex justify-center">
+      <div className="w-full max-w-sm space-y-5">
 
-      {/* ── Calendar ── */}
-      <section>
-        <div className="flex items-center justify-between mb-3">
-          <button
-            type="button"
-            onClick={prevMonth}
-            aria-label="Previous month"
-            className="w-7 h-7 flex items-center justify-center rounded-lg bg-neutral-800 text-neutral-400 hover:bg-neutral-700 hover:text-neutral-200 transition-all duration-150"
-          >
-            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
-              <path d="M7.5 2L3.5 6L7.5 10" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
-            </svg>
-          </button>
+        {/* ── Calendar ── */}
+        <section>
+          <div className="flex items-center justify-between mb-3">
+            <button
+              type="button"
+              onClick={prevMonth}
+              aria-label="Previous month"
+              className="w-7 h-7 flex items-center justify-center rounded-lg bg-neutral-800 text-neutral-400 hover:bg-neutral-700 hover:text-neutral-200 transition-all duration-150"
+            >
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+                <path d="M7.5 2L3.5 6L7.5 10" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+              </svg>
+            </button>
 
-          <span className="text-sm font-semibold text-neutral-200">
-            {MONTH_NAMES[viewMonth]} {viewYear}
-          </span>
-
-          <button
-            type="button"
-            onClick={nextMonth}
-            aria-label="Next month"
-            className="w-7 h-7 flex items-center justify-center rounded-lg bg-neutral-800 text-neutral-400 hover:bg-neutral-700 hover:text-neutral-200 transition-all duration-150"
-          >
-            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
-              <path d="M4.5 2L8.5 6L4.5 10" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
-            </svg>
-          </button>
-        </div>
-
-        {/* Day headers */}
-        <div className="grid grid-cols-7 mb-1">
-          {DAY_LABELS.map((d) => (
-            <div key={d} className="text-center text-[10px] font-medium text-neutral-500 py-1">
-              {d}
-            </div>
-          ))}
-        </div>
-
-        {/* Day cells */}
-        <div className="grid grid-cols-7 gap-1">
-          {/* Empty cells for offset */}
-          {Array.from({ length: firstDayOfWeek }).map((_, i) => (
-            <div key={`empty-${i}`} />
-          ))}
-
-          {days.map((day) => {
-            const key = toDateKey(day);
-            const score = entryMap.get(key);
-            const isToday = key === todayKey;
-            const hasEntry = score !== undefined;
-
-            return (
-              <div
-                key={key}
-                title={hasEntry ? `Mood: ${score}/10 — ${getMoodEmoji(score).label}` : undefined}
-                className={`
-                  relative flex items-center justify-center
-                  h-8 rounded-lg text-xs font-medium border transition-all duration-150
-                  ${hasEntry
-                    ? `${getMoodColor(score)} text-white cursor-default`
-                    : isToday
-                    ? "border-blue-500 text-blue-400 bg-blue-950/30"
-                    : "border-neutral-700 text-neutral-500 bg-neutral-800/50"
-                  }
-                `}
-              >
-                {day.getDate()}
-                {isToday && (
-                  <span className="absolute bottom-0.5 left-1/2 -translate-x-1/2 w-1 h-1 rounded-full bg-blue-400" aria-hidden="true" />
-                )}
-              </div>
-            );
-          })}
-        </div>
-
-        {/* Legend */}
-        <div className="flex items-center gap-3 mt-3 flex-wrap">
-          <span className="text-[10px] text-neutral-500">Mood scale:</span>
-          {[
-            { label: "1–2", cls: "bg-red-900/70 border-red-700" },
-            { label: "3–4", cls: "bg-orange-900/70 border-orange-700" },
-            { label: "5–6", cls: "bg-yellow-900/70 border-yellow-700" },
-            { label: "7–8", cls: "bg-blue-900/70 border-blue-600" },
-            { label: "9–10", cls: "bg-green-900/70 border-green-600" },
-          ].map(({ label, cls }) => (
-            <div key={label} className="flex items-center gap-1">
-              <div className={`w-3 h-3 rounded border ${cls}`} aria-hidden="true" />
-              <span className="text-[10px] text-neutral-500">{label}</span>
-            </div>
-          ))}
-        </div>
-      </section>
-
-      {/* ── Emoji Quick-Select ── */}
-      <section>
-        <label className="block text-xs font-semibold uppercase tracking-wider text-neutral-400 mb-3">
-          How are you feeling today?
-        </label>
-        <div className="flex gap-2 justify-between">
-          {EMOJI_OPTIONS.map(({ score, emoji, label }) => {
-            const isSelected = selectedScore !== null &&
-              selectedScore >= score - 1 && selectedScore <= score;
-
-            return (
-              <button
-                key={score}
-                type="button"
-                onClick={() => onMoodSelect?.(score)}
-                aria-label={`Mood: ${label} (${score} out of 10)`}
-                aria-pressed={isSelected}
-                className={`
-                  flex-1 flex flex-col items-center justify-center gap-1.5
-                  py-2.5 rounded-xl border text-xs font-medium transition-all duration-150
-                  ${isSelected
-                    ? "bg-blue-900/60 border-blue-500 text-blue-300 scale-105"
-                    : "bg-neutral-800 border-neutral-700 text-neutral-400 hover:border-neutral-500 hover:text-neutral-300 active:scale-95"
-                  }
-                `}
-              >
-                <span className="text-xl leading-none" role="img" aria-hidden="true">{emoji}</span>
-                <span className="text-[10px]">{label}</span>
-              </button>
-            );
-          })}
-        </div>
-      </section>
-
-      {/* ── Fine-tune Slider ── */}
-      <section>
-        <div className="flex items-center justify-between mb-2">
-          <label
-            htmlFor="mood-slider"
-            className="text-xs font-semibold uppercase tracking-wider text-neutral-400"
-          >
-            Fine-tune score
-          </label>
-          {selectedScore && currentMood && (
-            <span className="text-xs font-semibold text-blue-400">
-              {selectedScore}/10 — {currentMood.label}
+            <span className="text-sm font-semibold text-neutral-200">
+              {MONTH_NAMES[viewMonth]} {viewYear}
             </span>
-          )}
-        </div>
-        <input
-          id="mood-slider"
-          type="range"
-          min={1}
-          max={10}
-          step={1}
-          value={selectedScore ?? 5}
-          onChange={(e) => onMoodSelect?.(Number(e.target.value))}
-          aria-label="Fine-tune your mood score from 1 to 10"
-          aria-valuemin={1}
-          aria-valuemax={10}
-          aria-valuenow={selectedScore ?? 5}
-          className="w-full accent-blue-500 cursor-pointer"
-        />
-        <div className="flex justify-between text-[10px] text-neutral-500 mt-1">
-          <span>1 — Very low</span>
-          <span>10 — Very high</span>
-        </div>
-      </section>
 
+            <button
+              type="button"
+              onClick={nextMonth}
+              aria-label="Next month"
+              className="w-7 h-7 flex items-center justify-center rounded-lg bg-neutral-800 text-neutral-400 hover:bg-neutral-700 hover:text-neutral-200 transition-all duration-150"
+            >
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+                <path d="M4.5 2L8.5 6L4.5 10" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+              </svg>
+            </button>
+          </div>
+
+          {/* Day headers */}
+          <div className="grid grid-cols-7 mb-1">
+            {DAY_LABELS.map((d) => (
+              <div key={d} className="text-center text-[10px] font-medium text-neutral-500 py-1">
+                {d}
+              </div>
+            ))}
+          </div>
+
+          {/* Day cells */}
+          <div className="grid grid-cols-7 gap-1">
+            {/* Empty cells for offset */}
+            {Array.from({ length: firstDayOfWeek }).map((_, i) => (
+              <div key={`empty-${i}`} />
+            ))}
+
+            {days.map((day) => {
+              const key = toDateKey(day);
+              const score = entryMap.get(key);
+              const isToday = key === todayKey;
+              const hasEntry = score !== undefined;
+
+              return (
+                <div
+                  key={key}
+                  title={hasEntry ? `Mood: ${score}/10 — ${getMoodEmoji(score).label}` : undefined}
+                  className={`
+                    relative flex items-center justify-center
+                    h-8 rounded-lg text-xs font-medium border transition-all duration-150
+                    ${hasEntry
+                      ? `${getMoodColor(score)} text-white cursor-default`
+                      : isToday
+                      ? "border-blue-500 text-blue-400 bg-blue-950/30"
+                      : "border-neutral-700 text-neutral-500 bg-neutral-800/50"
+                    }
+                  `}
+                >
+                  {day.getDate()}
+                  {isToday && (
+                    <span className="absolute bottom-0.5 left-1/2 -translate-x-1/2 w-1 h-1 rounded-full bg-blue-400" aria-hidden="true" />
+                  )}
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Legend */}
+          <div className="flex items-center gap-3 mt-3 flex-wrap">
+            <span className="text-[10px] text-neutral-500">Mood scale:</span>
+            {[
+              { label: "1–2", cls: "bg-red-900/70 border-red-700" },
+              { label: "3–4", cls: "bg-orange-900/70 border-orange-700" },
+              { label: "5–6", cls: "bg-yellow-900/70 border-yellow-700" },
+              { label: "7–8", cls: "bg-blue-900/70 border-blue-600" },
+              { label: "9–10", cls: "bg-green-900/70 border-green-600" },
+            ].map(({ label, cls }) => (
+              <div key={label} className="flex items-center gap-1">
+                <div className={`w-3 h-3 rounded border ${cls}`} aria-hidden="true" />
+                <span className="text-[10px] text-neutral-500">{label}</span>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* ── Emoji Quick-Select ── */}
+        <section>
+          <label className="block text-xs font-semibold uppercase tracking-wider text-neutral-400 mb-3">
+            How are you feeling today?
+          </label>
+          <div className="flex gap-2 justify-between">
+            {EMOJI_OPTIONS.map(({ score, emoji, label }) => {
+              const isSelected = selectedScore !== null &&
+                selectedScore >= score - 1 && selectedScore <= score;
+
+              return (
+                <button
+                  key={score}
+                  type="button"
+                  onClick={() => onMoodSelect?.(score)}
+                  aria-label={`Mood: ${label} (${score} out of 10)`}
+                  aria-pressed={isSelected}
+                  className={`
+                    flex-1 flex flex-col items-center justify-center gap-1.5
+                    py-2.5 rounded-xl border text-xs font-medium transition-all duration-150
+                    ${isSelected
+                      ? "bg-blue-900/60 border-blue-500 text-blue-300 scale-105"
+                      : "bg-neutral-800 border-neutral-700 text-neutral-400 hover:border-neutral-500 hover:text-neutral-300 active:scale-95"
+                    }
+                  `}
+                >
+                  <span className="text-xl leading-none" role="img" aria-hidden="true">{emoji}</span>
+                  <span className="text-[10px]">{label}</span>
+                </button>
+              );
+            })}
+          </div>
+        </section>
+
+        {/* ── Fine-tune Slider ── */}
+        <section>
+          <div className="flex items-center justify-between mb-2">
+            <label
+              htmlFor="mood-slider"
+              className="text-xs font-semibold uppercase tracking-wider text-neutral-400"
+            >
+              Fine-tune score
+            </label>
+            {selectedScore && currentMood && (
+              <span className="text-xs font-semibold text-blue-400">
+                {selectedScore}/10 — {currentMood.label}
+              </span>
+            )}
+          </div>
+          <input
+            id="mood-slider"
+            type="range"
+            min={1}
+            max={10}
+            step={1}
+            value={selectedScore ?? 5}
+            onChange={(e) => onMoodSelect?.(Number(e.target.value))}
+            aria-label="Fine-tune your mood score from 1 to 10"
+            aria-valuemin={1}
+            aria-valuemax={10}
+            aria-valuenow={selectedScore ?? 5}
+            className="w-full accent-blue-500 cursor-pointer"
+          />
+          <div className="flex justify-between text-[10px] text-neutral-500 mt-1">
+            <span>1 — Very low</span>
+            <span>10 — Very high</span>
+          </div>
+        </section>
+
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## What Changed

MoodInputWidget:
- Added responsive wrapper (w-full flex justify-center, max-w-sm) so the widget no longer stretches full screen on desktop.
- Fixed slider and emoji buttons to sync with moodScore state by wiring selectedScore and onMoodSelect props in log/page.tsx.
- Added moodScore state to LogPage and passed it down to MoodInputWidget.

BottomNav:
- Changed "Resources" nav item to "Search" for the Search & Retrieve page
- Added the "Resources" link in the Dashboard page for easier access
- Changed label of the Log page from "Log" to "Mood Log"

## Checklist
- [x] PR to Dev
- [x] App runs without errors
- [x] No .env files committed
