### PR TITLE
S4-KM-02: Expand KM taxonomy and architecture for Peer Support Forum

### DIFF
--- a/docs/km-architecture.md
+++ b/docs/km-architecture.md
@@ -1,12 +1,19 @@
 # Knowledge Management Architecture
 
 ## 1. Executive Summary
+
 This document defines the Knowledge Taxonomy and Retrieval Requirements for the Student Mental Health & Wellness Tracker. It applies the **SECI Model** to ensure that raw user data is transformed into actionable self-knowledge. Our application functions as a **"Ba"** (knowledge space) where interaction bridges the gap between mere self-tracking and true self-quantification.
 
+The application is designed around the full SECI spiral — from private mood logging and journaling (Externalization), through dashboard analytics (Combination), to reflective goal-setting (Internalization). It also includes a **Peer Support Forum** — a safe, anonymous space where students share daily experiences, access coping resources, and find peer support stories — which enacts the **Socialization** stage of the SECI model. The forum is grounded in **Communities of Practice** theory (Wenger, 1998), applied at the peer-support layer only, while the individual self-tracking features retain the SECI model as their primary framework.
+
+---
+
 ## 2. Knowledge Taxonomy
+
 The following taxonomy is based on validated academic research regarding student stressors and coping strategies.
 
 ### 2.1 Stressors and Triggers (Externalization Phase)
+
 These tags allow students to convert tacit, unspoken distress into explicit, measurable units.
 
 | Broad Category | Specific Tags for Database | Research Source |
@@ -18,6 +25,7 @@ These tags allow students to convert tacit, unspoken distress into explicit, mea
 | **Digital** | #InformationOverload, #InternetAddiction, #TimeManagement | Zhong et al. (2024) |
 
 ### 2.2 Coping & Behavioral Responses (Combination Phase)
+
 These categories help the system organize fragmented data into a complex representation of the student's well-being.
 
 | Response Category | Specific Tags for Database | Description |
@@ -27,14 +35,60 @@ These categories help the system organize fragmented data into a complex represe
 | **Avoidance** | #Denial, #SelfDistraction, #Disengagement | Distancing oneself from stressors/emotions. |
 | **Support Seeking** | #InstrumentalSupport, #EmotionalSupport | Reaching out to others for advice or comfort. |
 
-## 3. Retrieval Requirements
+### 2.3 Peer Forum Content Tags (Socialization Phase)
+
+These tags classify shared peer stories and support posts in the forum. They enable students to find relevant peer experiences and facilitate the transfer of tacit coping knowledge through shared narrative — the defining mechanism of Socialization in the SECI model.
+
+| Content Category | Specific Tags for Database | Description |
+| :--- | :--- | :--- |
+| **Shared Experience** | #MyStory, #RelatableMoment, #YouAreNotAlone | Personal narratives shared to normalize student struggles. |
+| **Peer Advice** | #WhatHelpedMe, #TipFromAStudent, #LessonsLearned | Practical suggestions drawn from lived experience. |
+| **Resource Sharing** | #AppRecommendation, #CampusResource, #HelpfulReading | Pointers to tools, services, or materials found useful. |
+| **Community Support** | #CheckingIn, #NeedSupport, #PositiveVibes | Posts oriented toward emotional connection and solidarity. |
+
+---
+
+## 3. Full SECI-to-Feature Mapping
+
+| SECI Stage | KM Mechanism | App Feature | Description |
+| :--- | :--- | :--- | :--- |
+| **Socialization** | Tacit → Tacit (shared experience) | **Peer Support Forum** | Students share anonymous stories and peer advice, transferring tacit coping knowledge through lived narrative. Grounded in Communities of Practice (Wenger, 1998). |
+| **Externalization** | Tacit → Explicit | Mood Tracker + Journal with Tags | Students convert internal emotional states into structured logs and tagged journal entries using the research-based taxonomy (Sections 2.1–2.2). |
+| **Combination** | Explicit + Explicit | Dashboard & Analytics | Aggregates mood logs, sleep data, stressor tags, and coping tags into trend visualizations and cross-indicator patterns. |
+| **Internalization** | Explicit → Tacit | Reflective Insights + Wellness Goals | Students absorb dashboard trends as renewed self-understanding and commit to behavioral goals, closing the SECI spiral. |
+
+---
+
+## 4. Retrieval Requirements
+
 To facilitate the **Combination** and **Internalization** phases, the Developer (@enzo-q) must implement the following logic in the Supabase schema:
 
 1. **Tag-Based Filtering:** The system must allow users to query logs by specific stressor tags (e.g., "Show all entries tagged #TestStress").
 2. **Data Aggregation:** The architecture must facilitate the synthesis of fragmented mood tags with disparate datasets such as sleep quality or academic performance.
 3. **Pattern Identification:** The retrieval design must allow the student to identify latent triggers, such as how #PeerStress might correlate with diminished sleep quality.
+4. **Forum Retrieval:** The forum must support filtering posts by `forum_tags` to allow students to find peer stories relevant to their current stressor. Anonymous posts must never expose `user_id` in any query result.
 
-## 4. References
-* Almalki, M., Gray, K., & Sanchez, F. M. (2015). The use of self-quantification systems for personal health information. *Health Information Science and Systems*.
-* Lin, Y. M., & Chen, F. S. (2009). Academic stress inventory of students at universities and colleges of technology. *World Transactions on Engineering and Technology Education*.
-* Zhang, C., Yang, Y., & Liu, C. (2022). Knowledge management-based mental health service model. *Sustainability*.
+---
+
+## 5. Why Two Frameworks (SECI + Communities of Practice)
+
+The architecture selected the **SECI Model** as its primary framework because mental health self-tracking is a private, individual process — social stigma and labeling effects (Huang & Bashir, 2017) make communal knowledge-sharing inappropriate for the core journaling and mood-logging features.
+
+The Peer Support Forum introduces a **bounded application of Communities of Practice** at the social layer only. The forum is:
+- **Anonymous** — removing the stigma barrier that makes CoP unsuitable for the private layers
+- **Opt-in** — students engage with peer content on their own terms, after they have already externalized their own experience privately
+- **Tag-structured** — forum content is organized by the same taxonomy that governs private logs, ensuring semantic consistency across both layers
+
+This dual-framework design means the SECI spiral runs at the **individual level** (private mood logs → dashboard → goals) while Communities of Practice operates at the **social layer** (forum stories → peer knowledge transfer → normalized help-seeking behavior). The two frameworks are complementary, not competing.
+
+---
+
+## 6. References
+
+- Almalki, M., Gray, K., & Sanchez, F. M. (2015). The use of self-quantification systems for personal health information. *Health Information Science and Systems*.
+- Huang, H. Y., & Bashir, M. (2017). Users' adoption of mental health apps: Examining the impact of information cues. *JMIR mHealth and uHealth, 5*(6), e83.
+- Lin, Y. M., & Chen, F. S. (2009). Academic stress inventory of students at universities and colleges of technology. *World Transactions on Engineering and Technology Education*.
+- Nonaka, I., & Takeuchi, H. (1995). *The Knowledge-Creating Company*. Oxford University Press.
+- Wenger, E. (1998). *Communities of Practice: Learning, Meaning, and Identity*. Cambridge University Press.
+- Zhang, C., Yang, Y., & Liu, C. (2022). Knowledge management-based mental health service model. *Sustainability*.
+- Zhong, L., Cao, J., & Xue, F. (2024). The paradox of convenience: How information overload in mHealth apps leads to medical service overuse. *Frontiers in Public Health, 12*, 1408998.

--- a/docs/prompt-log-anthoncalban.md
+++ b/docs/prompt-log-anthoncalban.md
@@ -78,10 +78,22 @@
 
 ---
 
-## Summary of KM Contributions (Updated Sprint 3)
+## Sprint 4: Build Sprint 2 (Weeks 5–6)
+
+#### Prompt 10: Taxonomy Expansion for Peer Support Forum (S4-KM-01)
+**User Intent:** Updating `km-architecture.md` to account for the newly scoped Peer Support Forum feature — a safe, anonymous space where students share stories and coping resources — and ensuring the full SECI spiral is represented in the architecture.
+**Prompt:** "The project now includes a Peer Support Forum where students share their stories. The existing taxonomy covers Externalization and Combination but not Socialization. Help me extend `km-architecture.md` to include a forum tag vocabulary and update the SECI-to-feature mapping to reflect the Socialization stage. Also explain how Communities of Practice applies to the forum layer without replacing SECI for the private features."
+**AI Tool:** Claude
+**AI Response Summary:** Extended the taxonomy with a third layer — Peer Forum Content Tags (`forum_tags`) — covering four categories: Shared Experience, Peer Advice, Resource Sharing, and Community Support, with 12 specific tags for the `forum_posts` table. Updated the SECI-to-feature mapping table to include Socialization as a first-class row mapped to the Peer Support Forum. Added Section 5 (Why Two Frameworks) to `km-architecture.md`, articulating why Communities of Practice applies at the anonymous social layer while SECI governs the private individual features — a dual-framework design where the two are complementary rather than competing. Also included a developer note to @enzo-q specifying the `forum_posts` schema requirements (`forum_tags TEXT[]`, `is_anonymous BOOLEAN DEFAULT true`, and RLS anonymity enforcement).
+
+---
+
+## Summary of KM Contributions (Updated Sprint 4)
 - **Theory-to-Feature Mapping:** Successfully operationalized the **SECI Model** by mapping core app features (Mood Tracker, Journal, Dashboard, Goals) to specific knowledge conversion stages. This moved the project from a "passive tracker" to an active **Knowledge Management System**.
 - **Conceptual Infrastructure:** Defined and documented the application as a **"Cyber Ba"**—a secure, private knowledge space specifically designed to facilitate the transition from tacit emotional states to explicit, actionable data.
 - **Academic Validation:** Authored the first two major sections of the **KM Conceptual Report**, integrating 5 academic sources (including Nonaka, Takeuchi, and Almalki) to justify the project's technical architecture.
 - **Technical Oversight (Audit):** Completed the **Technical Audit (S3-KM-03)** by reviewing enzo-q's migration files against `km-architecture.md`, confirming that Auth/RLS and mood log constraints were correctly implemented, and identifying a critical KM gap in the tag vocabulary enforcement that breaks the Combination stage.
 - **Gap Documentation:** Filed a GitHub Issue (label: `km`, assigned to @enzo-q) formally documenting the uncontrolled tag vocabulary gap, including the affected columns, the SECI stage it breaks, the KM architecture requirement it violates, and the acceptance criteria for the fix.
+- **Taxonomy Expansion:** Extended `km-architecture.md` to include a third taxonomy layer — Peer Forum Content Tags — for the Socialization stage, completing the full SECI spiral across all four stages within the application architecture.
+- **Dual-Framework Design:** Integrated **Communities of Practice** (Wenger, 1998) at the anonymous peer forum layer alongside the existing SECI model, and formally documented the rationale for why the two frameworks are complementary rather than competing.
 - **Data Integrity:** Ensured that the "Externalization" phase of the app uses a structured ontology (standardized tags) rather than fragmented text, enabling higher-order "Combination" (analytics) in future sprints.


### PR DESCRIPTION
## Overview

This PR updates `docs/km-architecture.md` to reflect the expanded 
project scope including the Peer Support Forum feature, completing 
the full SECI spiral within the application architecture.

## Changes Made

- **Section 2.3 added** — Peer Forum Content Tags: a new third 
  taxonomy layer with 12 tags across 4 categories (Shared Experience, 
  Peer Advice, Resource Sharing, Community Support) for the 
  `forum_posts` table
- **Section 3 updated** — Full SECI-to-Feature Mapping table now 
  includes Socialization as a first-class row mapped to the Peer 
  Support Forum
- **Section 4 updated** — Forum retrieval requirement added 
  (`forum_tags` filtering + anonymity enforcement)
- **Section 5 added** — Dual-framework justification: why Communities 
  of Practice applies at the forum layer while SECI governs private 
  features
- **References updated** — Wenger (1998) added as CoP source

## Developer Note (@enzo-q)

Forum posts will require a `forum_posts` table with:
- `forum_tags TEXT[]` constrained to the Section 2.3 vocabulary
- `is_anonymous BOOLEAN DEFAULT true`
- RLS must never expose `user_id` in public forum queries

## Also Updated

- `docs/prompt-log-anthoncalban.md` updated with Sprint 4 AI 
  interactions (Prompt 10)