### PR TITLE
S3-UX-01 S3-UX-02 Update BottomNav and MoodInputWidget

### DIFF
--- a/src/app/log/page.tsx
+++ b/src/app/log/page.tsx
@@ -1,6 +1,6 @@
 import { ChevronLeft } from "lucide-react";
 import Link from "next/link";
-import { MoodLogForm } from "@/components/mood-log-form";
+import MoodLogClient from "@/components/MoodLogClient";
 import BottomNav from "@/components/BottomNav";
 
 export const metadata = { title: "Mood Log — SMHWT" };
@@ -35,8 +35,8 @@ export default function LogPage() {
       </header>
 
       <main className="px-4 pt-5 pb-32">
-        <MoodLogForm />
-      </main>
+  <MoodLogClient />
+</main>
 
       <BottomNav />
     </div>

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -13,8 +13,8 @@ type NavItem = {
 const navItems: NavItem[] = [
   {
     href: "/dashboard",
-    label: "Home",
-    ariaLabel: "Go to dashboard home",
+    label: "Dashboard",
+    ariaLabel: "Go to dashboard",
     icon: (active) => (
       <svg
         width="22"

--- a/src/components/MoodInputWidget.tsx
+++ b/src/components/MoodInputWidget.tsx
@@ -22,7 +22,10 @@ type MoodInputWidgetProps = {
 
 /** Returns a "YYYY-MM-DD" string for any Date */
 function toDateKey(date: Date): string {
-  return date.toISOString().split("T")[0];
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
 }
 
 /** Returns the emoji + label for a given mood score (1–10) */
@@ -125,7 +128,8 @@ export function MoodInputWidget({
   const currentMood = selectedScore ? getMoodEmoji(selectedScore) : null;
 
   return (
-    <div className="space-y-5">
+    <div className="w-full flex justify-center">
+      <div className="w-full max-w-sm space-y-5">
 
       {/* ── Calendar ── */}
       <section>
@@ -290,6 +294,7 @@ export function MoodInputWidget({
         </div>
       </section>
 
+    </div>
     </div>
   );
 }

--- a/src/components/MoodLogClient.tsx
+++ b/src/components/MoodLogClient.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { useState } from "react";
+import { MoodLogForm } from "@/components/mood-log-form";
+import { MoodInputWidget } from "@/components/MoodInputWidget";
+
+export default function MoodLogClient() {
+  const [moodScore, setMoodScore] = useState<number | null>(null);
+
+  return (
+    <div className="space-y-6">
+      <MoodInputWidget
+        selectedScore={moodScore}
+        onMoodSelect={(score) => setMoodScore(score)}
+      />
+      <MoodLogForm />
+    </div>
+  );
+}


### PR DESCRIPTION
## What Changed

BottomNav: 
- Renamed "Home" label to "Dashboard" to match the /dashboard route

MoodInputWidget::
- Added responsive wrapper (w-full flex justify-center, max-w-sm) — widget no longer stretches full screen on desktop
- Fixed timezone bug — calendar now uses local time instead of UTC so today's date highlights correctly (fixes off-by-one for PH timezone UTC+8)
- Added MoodLogClient.tsx as a client wrapper to hold moodScore state since log/page.tsx is a server component
- Emoji buttons and fine-tune slider now sync correctly via selectedScore and onMoodSelect props

## Checklist
- [x] PR to Dev
- [x] App runs without errors
- [x] No .env files committed