### PR TITLE
S3-UX Updated BottomNav and MoodInputWidget

### DIFF
--- a/src/app/log/page.tsx
+++ b/src/app/log/page.tsx
@@ -1,6 +1,6 @@
 import { ChevronLeft } from "lucide-react";
 import Link from "next/link";
-import { MoodLogForm } from "@/components/mood-log-form";
+import MoodLogClient from "@/components/MoodLogClient";
 import BottomNav from "@/components/BottomNav";
 
 export const metadata = { title: "Mood Log — SMHWT" };
@@ -35,8 +35,8 @@ export default function LogPage() {
       </header>
 
       <main className="px-4 pt-5 pb-32">
-        <MoodLogForm />
-      </main>
+  <MoodLogClient />
+</main>
 
       <BottomNav />
     </div>

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -13,8 +13,8 @@ type NavItem = {
 const navItems: NavItem[] = [
   {
     href: "/dashboard",
-    label: "Home",
-    ariaLabel: "Go to dashboard home",
+    label: "Dashboard",
+    ariaLabel: "Go to dashboard",
     icon: (active) => (
       <svg
         width="22"

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -14,7 +14,7 @@ const navItems: NavItem[] = [
   {
     href: "/dashboard",
     label: "Dashboard",
-    ariaLabel: "Go to dashboard",
+    ariaLabel: "Go to dashboard home",
     icon: (active) => (
       <svg
         width="22"
@@ -57,7 +57,7 @@ const navItems: NavItem[] = [
   },
   {
     href: "/log",
-    label: "Mood Log",
+    label: "Entries",
     ariaLabel: "Go to mood log entry",
     icon: (active) => (
       <svg
@@ -86,25 +86,38 @@ const navItems: NavItem[] = [
     ),
   },
   {
-    href: "/journal",
-    label: "Journal",
-    ariaLabel: "Go to journal entries",
-    icon: (active) => (
-      <svg
-        width="22"
-        height="22"
-        viewBox="0 0 22 22"
-        fill="none"
-        aria-hidden="true"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M4 5.5h14M4 11h9M4 16.5h11"
-          stroke="currentColor"
-          strokeWidth={active ? "1.8" : "1.4"}
-          strokeLinecap="round"
-        />
-      </svg>
+  href: "/stories",
+  label: "Stories",
+  ariaLabel: "Browse peer stories",
+  icon: (active) => (
+    <svg
+      width="22"
+      height="22"
+      viewBox="0 0 22 22"
+      fill="none"
+      aria-hidden="true"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <rect
+        x="4" y="3" width="9" height="12" rx="2"
+        stroke="currentColor"
+        strokeWidth={active ? "1.8" : "1.4"}
+        fill={active ? "currentColor" : "none"}
+        fillOpacity={active ? "0.12" : "0"}
+      />
+      <path
+        d="M7 7h3M7 10h3"
+        stroke="currentColor"
+        strokeWidth={active ? "1.8" : "1.4"}
+        strokeLinecap="round"
+      />
+      <path
+        d="M13 7h2a2 2 0 0 1 2 2v7a2 2 0 0 1-2 2H9a2 2 0 0 1-2-2v-1"
+        stroke="currentColor"
+        strokeWidth={active ? "1.8" : "1.4"}
+        strokeLinecap="round"
+      />
+    </svg>
     ),
   },
   {

--- a/src/components/MoodInputWidget.tsx
+++ b/src/components/MoodInputWidget.tsx
@@ -22,7 +22,10 @@ type MoodInputWidgetProps = {
 
 /** Returns a "YYYY-MM-DD" string for any Date */
 function toDateKey(date: Date): string {
-  return date.toISOString().split("T")[0];
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
 }
 
 /** Returns the emoji + label for a given mood score (1–10) */
@@ -125,7 +128,8 @@ export function MoodInputWidget({
   const currentMood = selectedScore ? getMoodEmoji(selectedScore) : null;
 
   return (
-    <div className="space-y-5">
+    <div className="w-full flex justify-center">
+      <div className="w-full max-w-sm space-y-5">
 
       {/* ── Calendar ── */}
       <section>
@@ -290,6 +294,7 @@ export function MoodInputWidget({
         </div>
       </section>
 
+    </div>
     </div>
   );
 }

--- a/src/components/MoodLogClient.tsx
+++ b/src/components/MoodLogClient.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { useState } from "react";
+import { MoodLogForm } from "@/components/mood-log-form";
+import { MoodInputWidget } from "@/components/MoodInputWidget";
+
+export default function MoodLogClient() {
+  const [moodScore, setMoodScore] = useState<number | null>(null);
+
+  return (
+    <div className="space-y-6">
+      <MoodInputWidget
+        selectedScore={moodScore}
+        onMoodSelect={(score) => setMoodScore(score)}
+      />
+      <MoodLogForm />
+    </div>
+  );
+}


### PR DESCRIPTION
## What Changed

[S3-UX-01] BottomNav: 
- Changed Home label to Dashboard
- Changed Log label to Entries, following the future changes for Mood and Journal
- Added a new nav item "Stories" for the upcoming Peer Stories feature
- Removed "Resources" from BottomNav

[S3-UX-03] MoodInputWidget::
- Added responsive wrapper (w-full flex justify-center, max-w-sm) — widget no longer stretches full screen on desktop
- Fixed timezone bug — calendar now uses local time instead of UTC so today's date highlights correctly (fixes off-by-one for PH timezone UTC+8)
- Added MoodLogClient.tsx as a client wrapper to hold moodScore state since log/page.tsx is a server component
- Emoji buttons and fine-tune slider now sync correctly via selectedScore and onMoodSelect props

## Checklist
- [x] PR to Dev
- [x] App runs without errors
- [x] No .env files committed