### PR TITLE
[S3-DEV] Update mood log form, log page, and log client

### DIFF
--- a/src/app/log/page.tsx
+++ b/src/app/log/page.tsx
@@ -1,9 +1,10 @@
 import { ChevronLeft } from "lucide-react";
 import Link from "next/link";
-import MoodLogClient from "@/components/MoodLogClient";
 import BottomNav from "@/components/BottomNav";
+// Import our tab switcher instead of MoodLogClient directly
+import { LogClient } from "@/components/log-client"; 
 
-export const metadata = { title: "Mood Log — SMHWT" };
+export const metadata = { title: "Daily Log — SMHWT" };
 
 function formatDate(date: Date): string {
   return date.toLocaleDateString("en-US", {
@@ -14,8 +15,8 @@ function formatDate(date: Date): string {
 }
 
 /**
- * /log — Mood Log entry page.
- * Journal entries have their own page at /journal (S3-DEV-03).
+ * /log — Combined Mood Log and Journal entry page.
+ * Uses <LogClient> for instant, client-side tab switching.
  */
 export default function LogPage() {
   const today = formatDate(new Date());
@@ -30,13 +31,14 @@ export default function LogPage() {
         >
           <ChevronLeft className="w-5 h-5" />
         </Link>
-        <h1 className="text-base font-semibold text-neutral-100">Mood log</h1>
+        <h1 className="text-base font-semibold text-neutral-100">Daily Log</h1>
         <span className="text-xs text-neutral-500">{today}</span>
       </header>
 
-      <main className="px-4 pt-5 pb-32">
-  <MoodLogClient />
-</main>
+      {/* Render the tab switcher here! */}
+      <main>
+        <LogClient />
+      </main>
 
       <BottomNav />
     </div>

--- a/src/components/MoodLogClient.tsx
+++ b/src/components/MoodLogClient.tsx
@@ -13,7 +13,8 @@ export default function MoodLogClient() {
         selectedScore={moodScore}
         onMoodSelect={(score) => setMoodScore(score)}
       />
-      <MoodLogForm />
+      
+      <MoodLogForm moodScore={moodScore} />
     </div>
   );
 }

--- a/src/components/log-client.tsx
+++ b/src/components/log-client.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useState } from "react";
+// 1. UPDATED IMPORT: Bring in the designer's wrapper instead of the raw form
+import MoodLogClient from "@/components/MoodLogClient"; 
+import { JournalEntryForm } from "@/components/journal-entry-form";
+
+export function LogClient() {
+  const [activeTab, setActiveTab] = useState<"mood" | "journal">("mood");
+
+  return (
+    <div className="px-4 pt-5 pb-32">
+      {/* ── Tab Switcher ── */}
+      <div className="flex bg-neutral-900/50 p-1 rounded-lg mb-8 border border-neutral-800">
+        <button
+          onClick={() => setActiveTab("mood")}
+          className={`flex-1 text-center py-2 rounded-md text-sm font-medium transition-all duration-200 ${
+            activeTab === "mood"
+              ? "bg-neutral-800 text-neutral-100 shadow-sm"
+              : "text-neutral-400 hover:text-neutral-200 hover:bg-neutral-800/50"
+          }`}
+        >
+          Mood
+        </button>
+        <button
+          onClick={() => setActiveTab("journal")}
+          className={`flex-1 text-center py-2 rounded-md text-sm font-medium transition-all duration-200 ${
+            activeTab === "journal"
+              ? "bg-neutral-800 text-neutral-100 shadow-sm"
+              : "text-neutral-400 hover:text-neutral-200 hover:bg-neutral-800/50"
+          }`}
+        >
+          Journal
+        </button>
+      </div>
+
+      {/* ── Active Form ── */}
+      {/* 2. UPDATED RENDER: Render the wrapper when 'mood' is active */}
+      {activeTab === "mood" ? <MoodLogClient /> : <JournalEntryForm />}
+    </div>
+  );
+}

--- a/src/components/mood-log-form.tsx
+++ b/src/components/mood-log-form.tsx
@@ -67,29 +67,34 @@ function TagGroup({
   );
 }
 
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+// 1. ADDED: Interface to accept moodScore from the designer's wrapper
+interface MoodLogFormProps {
+  moodScore: number | null;
+}
+
 // ── Main Component ────────────────────────────────────────────────────────────
 
-export function MoodLogForm() {
+// 2. ADDED: Accept the prop here
+export function MoodLogForm({ moodScore }: MoodLogFormProps) {
   const [state, formAction, isPending] = useActionState(
     saveMoodLog,
     initialState
   );
   const formRef = useRef<HTMLFormElement>(null);
 
-  const [moodScore, setMoodScore] = useState<number | null>(null);
+  // 3. REMOVED: local moodScore state (since it's now managed by the parent widget)
   const [sleepQuality, setSleepQuality] = useState<number | null>(null);
   const [academicImpact, setAcademicImpact] = useState("None");
   const [selectedStressors, setSelectedStressors] = useState<Set<string>>(new Set());
   const [selectedCoping, setSelectedCoping] = useState<Set<string>>(new Set());
 
-  // Add this new state to track the previous action state
   const [prevState, setPrevState] = useState(state);
 
-  // React official pattern: Reset local state during render when external state changes
   if (state !== prevState) {
     setPrevState(state);
     if (state.success) {
-      setMoodScore(null);
       setSleepQuality(null);
       setAcademicImpact("None");
       setSelectedStressors(new Set());
@@ -97,7 +102,6 @@ export function MoodLogForm() {
     }
   }
 
-  // Only manipulate the DOM (uncontrolled elements) inside the effect
   useEffect(() => {
     if (state.success) {
       formRef.current?.reset();
@@ -107,7 +111,6 @@ export function MoodLogForm() {
   function toggleStressor(tag: string) {
     setSelectedStressors((prev) => {
       const next = new Set(prev);
-      // Replaced the ternary operator with a standard if/else statement
       if (next.has(tag)) {
         next.delete(tag);
       } else {
@@ -120,7 +123,6 @@ export function MoodLogForm() {
   function toggleCoping(tag: string) {
     setSelectedCoping((prev) => {
       const next = new Set(prev);
-      // Replaced the ternary operator with a standard if/else statement
       if (next.has(tag)) {
         next.delete(tag);
       } else {
@@ -132,37 +134,11 @@ export function MoodLogForm() {
 
   return (
     <form ref={formRef} action={formAction} className="space-y-6">
-      {/* ── Mood Score ── */}
-      <section>
-        <label className="block text-xs font-semibold uppercase tracking-wider text-neutral-400 mb-3">
-          How are you feeling? (1–10)
-        </label>
-        <div className="flex gap-2 flex-wrap">
-          {Array.from({ length: 10 }, (_, i) => i + 1).map((n) => (
-            <button
-              key={n}
-              type="button"
-              onClick={() => setMoodScore(n)}
-              aria-pressed={moodScore === n}
-              className={`
-                w-9 h-9 rounded-lg text-sm font-semibold transition-all duration-150
-                ${
-                  moodScore === n
-                    ? "bg-blue-600 text-white shadow-md shadow-blue-900/40"
-                    : "bg-neutral-800 text-neutral-300 hover:bg-neutral-700"
-                }
-              `}
-            >
-              {n}
-            </button>
-          ))}
-        </div>
-        <div className="flex justify-between text-xs text-neutral-500 mt-1 px-0.5">
-          <span>Very low</span>
-          <span>Very high</span>
-        </div>
-        <input type="hidden" name="mood_score" value={moodScore ?? ""} readOnly />
-      </section>
+      
+      {/* 4. ADDED: Hidden input to pass the prop value into the Server Action */}
+      <input type="hidden" name="mood_score" value={moodScore ?? ""} readOnly />
+      
+      {/* 5. REMOVED: The old "How are you feeling?" buttons section */}
 
       {/* ── Optional Note ── */}
       <section>
@@ -304,7 +280,8 @@ export function MoodLogForm() {
       {/* ── Submit ── */}
       <button
         type="submit"
-        disabled={isPending || !moodScore || !sleepQuality}
+        // 6. UPDATED: Ensure we check that moodScore prop is not null
+        disabled={isPending || moodScore === null || !sleepQuality}
         className="w-full py-3 rounded-xl font-semibold text-sm transition-all duration-150 bg-blue-600 text-white hover:bg-blue-500 active:bg-blue-700 disabled:opacity-40 disabled:cursor-not-allowed"
       >
         {isPending ? "Saving..." : "Save mood log"}


### PR DESCRIPTION
## What changed
- Added a `log-client.tsx` that now imports the MoodLogClient instead of the raw `mood-log-form.tsx`
- Log page now imports `log-client.tsx`, where the tab switcher is, instead of MoodLogClient directly
- Added Hidden input in `mood-log-form.tsx` to pass prop value into the Server Action
- Added interface in `mood-log-form.tsx` to accept the moodScore from the MoodInputWidget
- Removed the old "How are you feeling?" section from the `mood-log-form.tsx`

## How to test
- Pull the branch locally and run `npm run dev`.
- Navigate to the Log (Entries) page (`/log`).
- See if it shows Mood and Journal via tab switching and if it works
- Try using the imported MoodInputWidget and see if the mood score is accepted

## Checklist
- [x] Forked from dev
- [x] App runs without errors
- [x] No .env files committed
- [x] No console.log in code