### PR TITLE
[S4-DEV-06] Build Admin Panel for Peer Story Moderation

### DIFF
--- a/docs/prompt-log-enzoq.md
+++ b/docs/prompt-log-enzoq.md
@@ -456,20 +456,26 @@
 
 ## Entry 20
 
-**Date:** May 1, 2026
+**Date:** May 2, 2026
 **Task:** S4-DEV-06 — Build Admin Panel for Peer Story Moderation
 
 ### Prompt Given
-> 
+> "Asked to build a highly protected `/admin` route for moderating peer support stories. Requested a database migration to establish an `is_admin` role, secure Server Actions to toggle story approval, and a client UI panel. Emphasized that regular users must be strictly redirected to `/dashboard` and that admin actions must be completely locked down."
 
 ### What the AI Produced
-
+- Generated the `profiles` table migration including an `is_admin` boolean flag and a Postgres trigger to auto-create profiles for new `auth.users`.
+- Created robust RLS policies allowing admins to bypass the `is_approved = true` public feed restriction to view and update pending stories.
+- Provided the `/admin` page routing logic with server-side redirects for non-admins.
+- Built the `AdminStoriesPanel` client component and the `toggleStoryApproval` Server Action.
 
 ### What I Changed, Rejected, or Improved
-
+- Rather than storing the admin flag directly in Supabase's `user_metadata` (which could potentially be spoofed depending on JWT configurations), I chose to implement a dedicated `profiles` table. This allows the `is_admin` status to be strictly enforced at the database level via secure RLS policies.
+- Implemented a "defense-in-depth" security model. I ensured the authorization check happens in three distinct places: at the page routing level (`page.tsx` redirect), inside the Server Action (`requireAdmin` guard), and at the database level (RLS). 
+- Designed a clean, Tailwind-based moderation UI with clear visual distinction (amber warning banners) to differentiate the Admin Panel from the standard user dashboard.
 
 ### What I Learned or Decided
-
+- Utilizing Postgres triggers (`handle_new_user`) is a powerful way to automatically synchronize custom `profiles` tables with the default Supabase `auth.users` system.
+- Secure moderation tools require defense-in-depth. Relying solely on hiding the UI is insufficient; the server actions and database rows must also be explicitly locked down to prevent API abuse.
 
 ---
 

--- a/src/app/actions/admin.ts
+++ b/src/app/actions/admin.ts
@@ -1,0 +1,85 @@
+"use server";
+
+import { createClient } from "@/lib/supabase/server";
+import { revalidatePath } from "next/cache";
+
+export type AdminStory = {
+  id: string;
+  title: string;
+  body: string;
+  forum_tags: string[];
+  is_approved: boolean;
+  created_at: string;
+  // submitted_by intentionally excluded from public type
+};
+
+/**
+ * Verifies the current user has is_admin = true in the profiles table.
+ * Used as a guard in all admin server actions.
+ */
+async function requireAdmin(): Promise<{ authorized: boolean; error?: string }> {
+  const supabase = await createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return { authorized: false, error: "Not authenticated." };
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("is_admin")
+    .eq("id", user.id)
+    .single();
+
+  if (!profile?.is_admin) {
+    return { authorized: false, error: "Access denied." };
+  }
+
+  return { authorized: true };
+}
+
+/**
+ * Fetch ALL stories for the admin panel (approved + pending).
+ * Ordered by created_at DESC so newest submissions appear first.
+ */
+export async function getAllStoriesForAdmin(): Promise<{
+  data: AdminStory[] | null;
+  error: string | null;
+}> {
+  const { authorized, error: authError } = await requireAdmin();
+  if (!authorized) return { data: null, error: authError ?? "Access denied." };
+
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from("peer_stories")
+    .select("id, title, body, forum_tags, is_approved, created_at")
+    .order("created_at", { ascending: false });
+
+  if (error) return { data: null, error: error.message };
+  return { data: data as AdminStory[], error: null };
+}
+
+/**
+ * Toggle the is_approved flag for a single story.
+ * Called from the Admin Panel approve/hide buttons.
+ */
+export async function toggleStoryApproval(
+  storyId: string,
+  currentValue: boolean
+): Promise<{ error: string | null }> {
+  const { authorized, error: authError } = await requireAdmin();
+  if (!authorized) return { error: authError ?? "Access denied." };
+
+  const supabase = await createClient();
+
+  const { error } = await supabase
+    .from("peer_stories")
+    .update({ is_approved: !currentValue })
+    .eq("id", storyId);
+
+  if (error) return { error: error.message };
+
+  revalidatePath("/admin");
+  revalidatePath("/stories");
+
+  return { error: null };
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,78 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { ShieldAlert } from "lucide-react";
+import { getAllStoriesForAdmin } from "@/app/actions/admin";
+import { AdminStoriesPanel } from "@/components/admin-stories-panel";
+import Link from "next/link";
+import { ChevronLeft } from "lucide-react";
+
+export const metadata = { title: "Admin — SMHWT" };
+
+/**
+ * /admin — Protected admin panel for moderating peer stories.
+ * Access is enforced at two levels:
+ *   1. Server: profiles.is_admin check via getAllStoriesForAdmin()
+ *   2. Page: explicit redirect if the user is not admin
+ * Regular users who navigate to /admin directly are redirected to /dashboard.
+ * The route is not linked anywhere in the public UI.
+ */
+export default async function AdminPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) redirect("/login");
+
+  // Check admin status at the page level before fetching anything
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("is_admin")
+    .eq("id", user.id)
+    .single();
+
+  if (!profile?.is_admin) redirect("/dashboard");
+
+  const { data: stories, error } = await getAllStoriesForAdmin();
+
+  return (
+    <div className="min-h-screen bg-neutral-950 text-neutral-100">
+      <header className="flex items-center justify-between px-4 py-4 border-b border-neutral-800">
+        <Link
+          href="/dashboard"
+          className="text-neutral-400 hover:text-neutral-200 transition-colors"
+          aria-label="Back to dashboard"
+        >
+          <ChevronLeft className="w-5 h-5" />
+        </Link>
+        <div className="flex items-center gap-2">
+          <ShieldAlert className="w-4 h-4 text-amber-500" />
+          <h1 className="text-base font-semibold text-neutral-100">
+            Admin Panel
+          </h1>
+        </div>
+        <span className="w-5" />
+      </header>
+
+      <main className="px-4 pt-5 pb-32 max-w-2xl mx-auto space-y-5">
+
+        <div className="px-4 py-3 rounded-xl bg-amber-950/30 border border-amber-800">
+          <p className="text-xs text-amber-300 leading-relaxed">
+            <span className="font-semibold">Moderator view.</span>{" "}
+            Stories must be approved before they appear in the public Peer Stories feed.
+            Hiding an approved story removes it from the feed immediately.
+          </p>
+        </div>
+
+        {error ? (
+          <p className="text-red-400 text-sm bg-red-950/40 border border-red-800 rounded-lg px-4 py-3">
+            Could not load stories: {error}
+          </p>
+        ) : (
+          <AdminStoriesPanel initialStories={stories ?? []} />
+        )}
+
+      </main>
+    </div>
+  );
+}

--- a/src/components/admin-stories-panel.tsx
+++ b/src/components/admin-stories-panel.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useTransition, useState } from "react";
+import { CheckCircle, EyeOff, Clock, BadgeCheck } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import { toggleStoryApproval, type AdminStory } from "@/app/actions/admin";
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+const BASE_BTN =
+  "flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold border transition-all duration-150 disabled:opacity-40 disabled:cursor-not-allowed";
+
+interface Props {
+  initialStories: AdminStory[];
+}
+
+export function AdminStoriesPanel({ initialStories }: Props) {
+  const [stories, setStories] = useState<AdminStory[]>(initialStories);
+  const [isPending, startTransition] = useTransition();
+  const [activeFilter, setActiveFilter] = useState<"all" | "pending" | "approved">("all");
+  const [feedbackId, setFeedbackId] = useState<string | null>(null);
+
+  const filtered = stories.filter((s) => {
+    if (activeFilter === "pending")  return !s.is_approved;
+    if (activeFilter === "approved") return s.is_approved;
+    return true;
+  });
+
+  const pendingCount  = stories.filter((s) => !s.is_approved).length;
+  const approvedCount = stories.filter((s) =>  s.is_approved).length;
+
+  function handleToggle(story: AdminStory) {
+    startTransition(async () => {
+      const { error } = await toggleStoryApproval(story.id, story.is_approved);
+      if (!error) {
+        setStories((prev) =>
+          prev.map((s) =>
+            s.id === story.id ? { ...s, is_approved: !s.is_approved } : s
+          )
+        );
+        setFeedbackId(story.id);
+        setTimeout(() => setFeedbackId(null), 2000);
+      }
+    });
+  }
+
+  return (
+    <div className="space-y-5">
+
+      {/* ── Summary stats ── */}
+      <div className="grid grid-cols-3 gap-3">
+        {[
+          { label: "Total",    count: stories.length,  filter: "all"      },
+          { label: "Pending",  count: pendingCount,    filter: "pending"  },
+          { label: "Approved", count: approvedCount,   filter: "approved" },
+        ].map(({ label, count, filter }) => {
+          const active = activeFilter === filter;
+          return (
+            <button
+              key={filter}
+              onClick={() => setActiveFilter(filter as typeof activeFilter)}
+              className={`rounded-xl border px-3 py-3 text-left transition-all duration-150
+                ${active
+                  ? "bg-neutral-800 border-neutral-600"
+                  : "bg-neutral-900 border-neutral-800 hover:border-neutral-700"
+                }`}
+            >
+              <p className="text-lg font-semibold text-neutral-100 leading-none">
+                {count}
+              </p>
+              <p className="text-[10px] text-neutral-500 mt-1">{label}</p>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* ── Story list ── */}
+      {filtered.length === 0 ? (
+        <div className="flex flex-col items-center gap-3 py-16 text-neutral-600">
+          <Clock className="w-10 h-10" />
+          <p className="text-sm">No stories in this category.</p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {filtered.map((story) => (
+            <Card
+              key={story.id}
+              className={`border transition-colors
+                ${story.is_approved
+                  ? "bg-neutral-900 border-green-900/50"
+                  : "bg-neutral-900 border-amber-900/50"
+                }`}
+            >
+              <CardContent className="pt-4 pb-4 space-y-3">
+
+                {/* Status badge */}
+                <div className="flex items-center justify-between gap-2">
+                  <div className="flex items-center gap-1.5">
+                    {story.is_approved ? (
+                      <>
+                        <BadgeCheck className="w-3.5 h-3.5 text-green-500" />
+                        <span className="text-[10px] font-semibold text-green-500 uppercase tracking-wider">
+                          Approved
+                        </span>
+                      </>
+                    ) : (
+                      <>
+                        <Clock className="w-3.5 h-3.5 text-amber-500" />
+                        <span className="text-[10px] font-semibold text-amber-500 uppercase tracking-wider">
+                          Pending
+                        </span>
+                      </>
+                    )}
+                  </div>
+                  <span className="text-[10px] text-neutral-600">
+                    {formatDate(story.created_at)}
+                  </span>
+                </div>
+
+                {/* Title */}
+                <p className="text-sm font-semibold text-neutral-100 leading-snug">
+                  {story.title}
+                </p>
+
+                {/* Body preview */}
+                <p className="text-xs text-neutral-400 leading-relaxed line-clamp-3">
+                  {story.body}
+                </p>
+
+                {/* Forum tags */}
+                {story.forum_tags.length > 0 && (
+                  <div className="flex flex-wrap gap-1.5">
+                    {story.forum_tags.map((tag) => (
+                      <Badge
+                        key={tag}
+                        variant="secondary"
+                        className="text-[10px] px-2 py-0.5 bg-neutral-800 text-neutral-400 border border-neutral-700"
+                      >
+                        {tag}
+                      </Badge>
+                    ))}
+                  </div>
+                )}
+
+                {/* Approve / Hide action */}
+                <div className="flex items-center justify-between pt-1">
+                  {feedbackId === story.id && (
+                    <span className="text-[10px] text-blue-400">
+                      Updated
+                    </span>
+                  )}
+                  <div className="ml-auto">
+                    {story.is_approved ? (
+                      <button
+                        onClick={() => handleToggle(story)}
+                        disabled={isPending}
+                        className={`${BASE_BTN} text-red-400 border-red-900 hover:bg-red-950/30`}
+                      >
+                        <EyeOff className="w-3.5 h-3.5" />
+                        Hide
+                      </button>
+                    ) : (
+                      <button
+                        onClick={() => handleToggle(story)}
+                        disabled={isPending}
+                        className={`${BASE_BTN} text-green-400 border-green-900 hover:bg-green-950/30`}
+                      >
+                        <CheckCircle className="w-3.5 h-3.5" />
+                        Approve
+                      </button>
+                    )}
+                  </div>
+                </div>
+
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/supabase/migrations/admin-role-migration.sql
+++ b/supabase/migrations/admin-role-migration.sql
@@ -1,0 +1,90 @@
+-- ============================================================
+-- Migration: Admin role + peer_stories admin RLS policies
+-- Sprint: S4 | Task: S4-DEV-06
+-- ============================================================
+
+-- ── profiles table ───────────────────────────────────────────
+-- Stores the is_admin flag. Keyed to auth.users.
+-- This is separate from user_metadata so RLS can enforce it
+-- at the database level without trusting client-supplied claims.
+
+CREATE TABLE IF NOT EXISTS public.profiles (
+  id         UUID        PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  is_admin   BOOLEAN     NOT NULL DEFAULT false,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.profiles FORCE  ROW LEVEL SECURITY;
+
+-- Users can read their own profile (so the app can check is_admin)
+DROP POLICY IF EXISTS "profiles: owner can select" ON public.profiles;
+CREATE POLICY "profiles: owner can select"
+  ON public.profiles FOR SELECT
+  USING (auth.uid() = id);
+
+-- Only the DB owner (service role) can insert/update profiles.
+-- is_admin must be set manually in the Supabase dashboard —
+-- it cannot be set through the app UI by any user.
+DROP POLICY IF EXISTS "profiles: service role only insert" ON public.profiles;
+CREATE POLICY "profiles: service role only insert"
+  ON public.profiles FOR INSERT
+  WITH CHECK (false);
+
+DROP POLICY IF EXISTS "profiles: service role only update" ON public.profiles;
+CREATE POLICY "profiles: service role only update"
+  ON public.profiles FOR UPDATE
+  USING (false);
+
+-- ── Auto-create profile on signup ────────────────────────────
+-- Trigger that inserts a profiles row when a new auth user is created.
+-- is_admin defaults to false for every new user.
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+  INSERT INTO public.profiles (id, is_admin)
+  VALUES (NEW.id, false)
+  ON CONFLICT (id) DO NOTHING;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();
+
+-- ── peer_stories admin RLS policies ──────────────────────────
+-- Admins need to SELECT all stories (including unapproved)
+-- and UPDATE is_approved to approve or hide them.
+
+DROP POLICY IF EXISTS "peer_stories: admin can select all" ON public.peer_stories;
+CREATE POLICY "peer_stories: admin can select all"
+  ON public.peer_stories FOR SELECT
+  USING (
+    is_approved = true
+    OR (
+      auth.uid() IS NOT NULL
+      AND EXISTS (
+        SELECT 1 FROM public.profiles
+        WHERE id = auth.uid() AND is_admin = true
+      )
+    )
+  );
+
+DROP POLICY IF EXISTS "peer_stories: admin can update approval" ON public.peer_stories;
+CREATE POLICY "peer_stories: admin can update approval"
+  ON public.peer_stories FOR UPDATE
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE id = auth.uid() AND is_admin = true
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE id = auth.uid() AND is_admin = true
+    )
+  );


### PR DESCRIPTION
## What changed
- Created the `profiles` table migration to handle user roles, establishing an `is_admin` flag (defaulting to `false`) and a Postgres trigger that automatically creates a profile when a new `auth.users` account is registered.
- Implemented Row Level Security (RLS) policies on the `peer_stories` table, explicitly allowing admins to `SELECT` all stories (including pending ones) and `UPDATE` the `is_approved` status.
- Built the highly protected `/admin` page route. Added server-side validation to check the `is_admin` flag; regular users attempting to access it are instantly redirected to `/dashboard`.
- Developed the `AdminStoriesPanel` client component and underlying Server Actions (`admin.ts`) to allow moderators to view, filter, and seamlessly toggle the "Approve" or "Hide" status of any peer story.
- Ensured the admin route remains strictly hidden and is not exposed in the main navigation for standard users.
- Added entry 20 in my `prompt-log-enzoq.md`

## How to test
- Pull the branch locally and run `npm run dev`.
- **Test as a regular user:** Log in normally and manually type `/admin` into your browser URL bar. Verify that you are immediately redirected back to `/dashboard`.
- **Test as an admin:** Open your local Supabase Studio, go to the `profiles` table, and manually set `is_admin` to `true` for your user account. 
- Navigate to `/admin` again. You should now be granted access to the Moderator View.
- Test toggling the "Approve" and "Hide" buttons on a few mock stories.
- Open the public Peer Stories feed (`/stories`) in another tab and verify that the feed instantly reflects your approval/hiding actions from the admin panel.

## Checklist
- [x] Forked from dev
- [x] App runs without errors
- [x] No .env files committed
- [x] No console.log in code