### PR TITLE
[S4-DEV-05] feat: add password change and account deletion to profile page

### DIFF
--- a/docs/prompt-log-enzoq.md
+++ b/docs/prompt-log-enzoq.md
@@ -432,25 +432,26 @@
 
 ## Entry 19
 
-**Date:** May 2, 2026
+**Date:** May 1, 2026
 **Task:** S4-DEV-05 — Build Dashboard and Profile
 
 ### Prompt Given
-> "Asked to implement the central `/dashboard` page hosting the `DashboardSummaryCard` for aggregated insights, and a dedicated `/profile` settings page for updating the user's display name. Also requested to redirect the root app page to `/dashboard`, extract a reusable sign-out component, remove the standalone Journal page, and update the prompt log with previous entries."
+> "Asked to implement the central `/dashboard` page for aggregated insights, and a `/profile` settings page for updating the user's display name. Later expanded the profile page to include secure password changes (`changePassword`) and safe account deletions (`requestAccountDeletion`) using `shadcn/ui` buttons. Also requested root redirects, extraction of a reusable sign-out component, and the removal of the standalone Journal page."
 
 ### What the AI Produced
-- Generated the `/dashboard` page logic, including the streak calculation function and recent entries fetch.
-- Created the `/profile` page and `profile-form.tsx` with a Server Action (`profile.ts`) to securely validate and update the user's display name in Supabase Auth.
-- Extracted a reusable `SignOutButton` component.
-- Updated the main root `page.tsx` to automatically redirect users to `/dashboard`.
+- Generated the `/dashboard` page logic, including streak calculations and recent entry fetches.
+- Created the `/profile` page with comprehensive Server Actions to safely update display names, change passwords via Supabase Auth, and flag accounts for deletion via user metadata.
+- Built the `ChangePasswordForm` and `DeleteAccountForm` client components styled with `shadcn/ui` Buttons.
+- Extracted a reusable `SignOutButton` component and updated the main root `page.tsx` to redirect to `/dashboard`.
 
 ### What I Changed, Rejected, or Improved
-- Intentionally deferred the "globally accessible avatar dropdown" as it is a UX/UI Designer deliverable (`S4-UX-06`). Instead, I focused on building the robust `/profile` settings layer beneath it and extracted the `SignOutButton` so the designer can seamlessly reuse my logic without duplicating code.
-- Manually consolidated the routing by deleting the standalone Journal page to ensure users rely on the central dashboard for navigation.
+- Intentionally deferred the "globally accessible avatar dropdown" as it is a UX/UI Designer deliverable (`S4-UX-06`), focusing instead on building the robust `/profile` settings layer beneath it.
+- Rejected and completely removed a suggested Theme Toggle feature, keeping the scope strictly focused on core account management.
+- Opted for a "soft delete" approach for `requestAccountDeletion` (using a metadata flag) rather than hard-deleting the user immediately. This safely preserves database relational integrity for their previous journal entries and peer stories.
 
 ### What I Learned or Decided
-- Supabase Auth's `user_metadata` is the ideal single source of truth for display names, preventing the need for a complex custom profiles table just for basic user info.
-- Extracting functional, logic-heavy components (like authentication buttons) early creates a much cleaner handoff for UI designers working on global layout components.
+- Supabase Auth's `user_metadata` is highly versatile—serving not just as a single source of truth for display names, but also as a secure place to store system-level account lifecycle flags (like deletion requests).
+- Consolidating account management (display name, password, deletion) into a single secure route with dedicated Server Actions keeps the application logic clean and much easier to secure.
 
 ---
 

--- a/src/app/actions/profile.ts
+++ b/src/app/actions/profile.ts
@@ -49,6 +49,62 @@ export async function updateUsername(
   return { success: true, message: "Username updated successfully." };
 }
 
+export async function changePassword(
+  _prev: ProfileFormState,
+  formData: FormData
+): Promise<ProfileFormState> {
+  const supabase = await createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return { success: false, error: "Not authenticated." };
+
+  const newPassword     = (formData.get("new_password")     as string | null) ?? "";
+  const confirmPassword = (formData.get("confirm_password") as string | null) ?? "";
+
+  if (!newPassword)
+    return { success: false, error: "Password cannot be empty." };
+  if (newPassword.length < 8)
+    return { success: false, error: "Password must be at least 8 characters." };
+  if (newPassword !== confirmPassword)
+    return { success: false, error: "Passwords do not match." };
+
+  const { error } = await supabase.auth.updateUser({ password: newPassword });
+
+  if (error) return { success: false, error: error.message };
+
+  return { success: true, message: "Password updated successfully." };
+}
+
+/**
+ * Marks the account for deletion by updating user_metadata.
+ * Hard deletion requires the service role key and is intentionally
+ * left for a manual admin action — this creates a clear audit trail.
+ */
+export async function requestAccountDeletion(
+  _prev: ProfileFormState,
+  formData: FormData
+): Promise<ProfileFormState> {
+  const supabase = await createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return { success: false, error: "Not authenticated." };
+
+  const confirmation = (formData.get("confirmation") as string | null)?.trim();
+  if (confirmation !== "DELETE")
+    return { success: false, error: 'Type DELETE (all caps) to confirm.' };
+
+  const { error } = await supabase.auth.updateUser({
+    data: { deletion_requested: true, deletion_requested_at: new Date().toISOString() },
+  });
+
+  if (error) return { success: false, error: error.message };
+
+  return {
+    success: true,
+    message: "Deletion request recorded. An admin will process this.",
+  };
+}
+
 /**
  * Sign out the current user and redirect to login.
  * Called from both the profile page and the header avatar dropdown.

--- a/src/components/change-password-form.tsx
+++ b/src/components/change-password-form.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useActionState, useEffect, useRef } from "react";
+import { changePassword, type ProfileFormState } from "@/app/actions/profile";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+const initialState: ProfileFormState = { success: false };
+
+export function ChangePasswordForm() {
+  const [state, formAction, isPending] = useActionState(
+    changePassword,
+    initialState
+  );
+  const formRef = useRef<HTMLFormElement>(null);
+
+  useEffect(() => {
+    if (state.success) {
+      formRef.current?.reset();
+    }
+  }, [state]);
+
+  return (
+    <form ref={formRef} action={formAction} className="space-y-4">
+      <div className="space-y-2">
+        <label
+          htmlFor="new_password"
+          className="block text-xs font-semibold uppercase tracking-wider text-neutral-400"
+        >
+          New password
+        </label>
+        <Input
+          id="new_password"
+          name="new_password"
+          type="password"
+          placeholder="At least 8 characters"
+          autoComplete="new-password"
+          className="bg-neutral-800 border-neutral-700 text-neutral-200 placeholder:text-neutral-500 focus-visible:ring-blue-600"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <label
+          htmlFor="confirm_password"
+          className="block text-xs font-semibold uppercase tracking-wider text-neutral-400"
+        >
+          Confirm password
+        </label>
+        <Input
+          id="confirm_password"
+          name="confirm_password"
+          type="password"
+          placeholder="Repeat your new password"
+          autoComplete="new-password"
+          className="bg-neutral-800 border-neutral-700 text-neutral-200 placeholder:text-neutral-500 focus-visible:ring-blue-600"
+        />
+      </div>
+
+      {state.error && (
+        <p className="text-red-400 text-sm bg-red-950/40 border border-red-800 rounded-lg px-4 py-2">
+          {state.error}
+        </p>
+      )}
+      {state.success && (
+        <p className="text-green-400 text-sm bg-green-950/40 border border-green-800 rounded-lg px-4 py-2">
+          {state.message}
+        </p>
+      )}
+
+      <Button
+        type="submit"
+        disabled={isPending}
+        className="w-full bg-blue-600 hover:bg-blue-500 text-white"
+      >
+        {isPending ? "Updating..." : "Update password"}
+      </Button>
+    </form>
+  );
+}

--- a/src/components/delete-account-form.tsx
+++ b/src/components/delete-account-form.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useActionState, useState } from "react";
+import { requestAccountDeletion, type ProfileFormState } from "@/app/actions/profile";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { TriangleAlert } from "lucide-react";
+
+const initialState: ProfileFormState = { success: false };
+
+export function DeleteAccountForm() {
+  const [state, formAction, isPending] = useActionState(
+    requestAccountDeletion,
+    initialState
+  );
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="space-y-3">
+      {!expanded ? (
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => setExpanded(true)}
+          className="w-full justify-start gap-3 bg-neutral-900 border-neutral-800 text-red-400 hover:bg-red-950/20 hover:border-red-900 hover:text-red-400"
+        >
+          <TriangleAlert className="w-4 h-4" />
+          Request account deletion
+        </Button>
+      ) : (
+        <form action={formAction} className="space-y-4">
+          <div className="px-4 py-3 rounded-xl bg-red-950/30 border border-red-800 space-y-1">
+            <p className="text-xs font-semibold text-red-400">
+              This action cannot be undone.
+            </p>
+            <p className="text-xs text-neutral-400 leading-relaxed">
+              All your mood logs, journal entries, and wellness goals will be
+              permanently deleted. Type{" "}
+              <span className="font-mono font-semibold text-neutral-200">
+                DELETE
+              </span>{" "}
+              below to confirm.
+            </p>
+          </div>
+
+          <Input
+            name="confirmation"
+            type="text"
+            placeholder="Type DELETE to confirm"
+            autoComplete="off"
+            className="bg-neutral-800 border-red-900 text-neutral-200 placeholder:text-neutral-600 focus-visible:ring-red-600"
+          />
+
+          {state.error && (
+            <p className="text-red-400 text-sm bg-red-950/40 border border-red-800 rounded-lg px-4 py-2">
+              {state.error}
+            </p>
+          )}
+          {state.success && (
+            <p className="text-green-400 text-sm bg-green-950/40 border border-green-800 rounded-lg px-4 py-2">
+              {state.message}
+            </p>
+          )}
+
+          <div className="flex gap-3">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setExpanded(false)}
+              className="flex-1 bg-neutral-900 border-neutral-800 text-neutral-400 hover:bg-neutral-800"
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={isPending || state.success}
+              className="flex-1 bg-red-700 hover:bg-red-600 text-white"
+            >
+              {isPending ? "Submitting..." : "Confirm deletion"}
+            </Button>
+          </div>
+        </form>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## What changed
- Added the `changePassword` Server Action to securely handle user password updates directly through Supabase Auth.
- Added the `requestAccountDeletion` Server Action, which safely handles deletion requests by updating a deletion flag in the user's metadata rather than hard-deleting records immediately.
- Built and integrated the `ChangePasswordForm` and `DeleteAccountForm` client components into the Profile settings page.
- Now started utilizing `shadcn/ui` `Button` components across the new forms to ensure consistent, accessible styling.
- Updated entry 19 of my `prompt-log-enzoq.md`.

## How to test
- Pull the branch locally and run `npm run dev`.
- Navigate to the `/profile` page.
- **Change Password:** Use the `ChangePasswordForm` to submit a new password. Verify the success state in the UI, sign out, and try logging back in with the new password to confirm the Supabase Auth update.
- **Account Deletion:** Submit a request through the `DeleteAccountForm`. Open Supabase, check the `auth.users` table (or profiles table/metadata), and verify that the deletion flag was successfully applied to your user record.

## Checklist
- [x] Forked from dev
- [x] App runs without errors
- [x] No .env files committed
- [x] No console.log in code