### PR TITLE
[S4-DEV-05] feat: update profile UI with shadcn buttons and admin routing

### DIFF
--- a/docs/prompt-log-enzoq.md
+++ b/docs/prompt-log-enzoq.md
@@ -436,22 +436,23 @@
 **Task:** S4-DEV-05 — Build Dashboard and Profile
 
 ### Prompt Given
-> "Asked to implement the central `/dashboard` page for aggregated insights, and a `/profile` settings page for updating the user's display name. Later expanded the profile page to include secure password changes (`changePassword`) and immediate account deletion using a Supabase RPC. Requested `shadcn/ui` buttons, a 'DELETE' confirmation guard, root redirects, extraction of a reusable sign-out component, and the removal of the standalone Journal page."
+> "Asked to implement the central `/dashboard` page and a `/profile` settings page. Later expanded the profile page to include password changes, a 'Danger Zone' for immediate account deletion via Supabase RPC, and a conditionally rendered link to the Admin Panel for moderators. Requested refactoring `ProfileForm` and `SignOutButton` to use `shadcn/ui` Buttons, root redirects, and the removal of the standalone Journal page."
 
 ### What the AI Produced
 - Generated the `/dashboard` page logic, including streak calculations and recent entry fetches.
-- Created the `/profile` page with comprehensive Server Actions to safely update display names, change passwords via Supabase Auth, and instantly delete the account via a Supabase RPC.
-- Built the `ChangePasswordForm` and `DeleteAccountForm` client components styled with `shadcn/ui` Buttons, including the strict "DELETE" input confirmation.
-- Extracted a reusable `SignOutButton` component and updated the main root `page.tsx` to redirect to `/dashboard`.
+- Created the `/profile` page with comprehensive Server Actions to safely update display names, change passwords, and instantly delete the account via a Supabase RPC.
+- Refactored UI components (`ProfileForm`, `SignOutButton`, `ChangePasswordForm`, `DeleteAccountForm`) to utilize consistent `shadcn/ui` Button styling.
+- Added server-side logic to fetch the user's `is_admin` status and conditionally render an Admin Panel navigation link.
 
 ### What I Changed, Rejected, or Improved
 - Intentionally deferred the "globally accessible avatar dropdown" as it is a UX/UI Designer deliverable (`S4-UX-06`), focusing instead on building the robust `/profile` settings layer beneath it.
-- Rejected and completely removed a suggested Theme Toggle feature, keeping the scope strictly focused on core account management.
-- Pivoted from my original "soft delete" metadata idea to a complete, immediate **hard deletion** using a Supabase RPC. Added the "DELETE" confirmation requirement to prevent accidental self-destruction.
+- Rejected a suggested Theme Toggle feature, keeping the scope strictly focused on core account management.
+- Pivoted from my original "soft delete" metadata idea to a complete, immediate **hard deletion** using a Supabase RPC, requiring a strict "DELETE" text confirmation to prevent accidental self-destruction.
+- Grouped the destructive account actions into a standard "Danger Zone" UI pattern to improve UX and visual hierarchy.
 
 ### What I Learned or Decided
-- Supabase prevents users from directly deleting their own `auth.users` record for security reasons. Using an RPC (Remote Procedure Call) defined in the database allows a user to securely trigger their own deletion without needing a service role key on the client or server.
-- Cascading deletes at the database level (on profiles, journal entries, and stories) ensures strict privacy compliance when a user decides to leave the platform, leaving no orphaned data behind.
+- Supabase prevents users from directly deleting their own `auth.users` record for security reasons. Using an RPC allows a user to securely trigger their own deletion without needing a service role key on the client.
+- Fetching user roles (like `is_admin`) directly in Next.js Server Components allows for secure, seamless conditional UI rendering (like the Admin link) without any client-side layout shift or exposed state.
 
 ---
 

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,23 +1,15 @@
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
-import { ChevronLeft } from "lucide-react";
+import { ChevronLeft, ShieldAlert } from "lucide-react";
 import Link from "next/link";
 import BottomNav from "@/components/BottomNav";
 import { ProfileForm } from "@/components/profile-form";
+import { ChangePasswordForm } from "@/components/change-password-form";
 import { SignOutButton } from "@/components/sign-out-button";
+import { DeleteAccountForm } from "@/components/delete-account-form";
 
 export const metadata = { title: "Profile — SMHWT" };
 
-/**
- * /profile — Account settings page.
- * Handles username updates via ProfileForm (server action).
- * SignOutButton is extracted as a shared component so the designer's
- * header avatar dropdown can reuse it without duplicating logic.
- *
- * NOTE: The avatar/ProfileCard component in the header is a UX/UI
- * Designer deliverable (S4-UX-06). This page provides the settings
- * layer that sits beneath it.
- */
 export default async function ProfilePage() {
   const supabase = await createClient();
   const {
@@ -25,6 +17,15 @@ export default async function ProfilePage() {
   } = await supabase.auth.getUser();
 
   if (!user) redirect("/login");
+
+  // Check admin status server-side — never passed to client
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("is_admin")
+    .eq("id", user.id)
+    .single();
+
+  const isAdmin = profile?.is_admin ?? false;
 
   const displayName =
     user.user_metadata?.full_name?.split(" ")[0] ??
@@ -66,10 +67,47 @@ export default async function ProfilePage() {
                 {user.id}
               </span>
             </div>
+            {isAdmin && (
+              <>
+                <div className="border-t border-neutral-800" />
+                <div className="flex justify-between items-center">
+                  <span className="text-xs text-neutral-500">Role</span>
+                  <div className="flex items-center gap-1.5">
+                    <ShieldAlert className="w-3 h-3 text-amber-500" />
+                    <span className="text-xs text-amber-400 font-semibold">
+                      Admin
+                    </span>
+                  </div>
+                </div>
+              </>
+            )}
           </div>
         </section>
 
-        {/* ── Username update ── */}
+        {/* ── Admin Panel link (admin only) ── */}
+        {isAdmin && (
+          <section className="space-y-3">
+            <p className="text-xs font-semibold uppercase tracking-wider text-neutral-500">
+              Administration
+            </p>
+            <Link
+              href="/admin"
+              className="flex items-center justify-between w-full px-4 py-3 rounded-xl bg-amber-950/20 border border-amber-900 hover:bg-amber-950/40 transition-colors group"
+            >
+              <div className="flex items-center gap-3">
+                <ShieldAlert className="w-4 h-4 text-amber-500" />
+                <span className="text-sm font-medium text-amber-300">
+                  Open Admin Panel
+                </span>
+              </div>
+              <span className="text-xs text-amber-700 group-hover:text-amber-500 transition-colors">
+                Moderate peer stories →
+              </span>
+            </Link>
+          </section>
+        )}
+
+        {/* ── Display name ── */}
         <section className="space-y-3">
           <p className="text-xs font-semibold uppercase tracking-wider text-neutral-500">
             Display name
@@ -79,12 +117,30 @@ export default async function ProfilePage() {
           </div>
         </section>
 
-        {/* ── Sign out ── */}
+        {/* ── Change password ── */}
+        <section className="space-y-3">
+          <p className="text-xs font-semibold uppercase tracking-wider text-neutral-500">
+            Password
+          </p>
+          <div className="bg-neutral-900 border border-neutral-800 rounded-xl px-4 py-4">
+            <ChangePasswordForm />
+          </div>
+        </section>
+
+        {/* ── Session ── */}
         <section className="space-y-3">
           <p className="text-xs font-semibold uppercase tracking-wider text-neutral-500">
             Session
           </p>
           <SignOutButton />
+        </section>
+
+        {/* ── Danger zone ── */}
+        <section className="space-y-3">
+          <p className="text-xs font-semibold uppercase tracking-wider text-red-900">
+            Danger zone
+          </p>
+          <DeleteAccountForm />
         </section>
 
       </main>

--- a/src/components/profile-form.tsx
+++ b/src/components/profile-form.tsx
@@ -3,6 +3,7 @@
 import { useActionState, useEffect, useRef } from "react";
 import { updateUsername, type ProfileFormState } from "@/app/actions/profile";
 import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
 
 const initialState: ProfileFormState = { success: false };
 
@@ -17,7 +18,6 @@ export function ProfileForm({ currentUsername }: Props) {
   );
   const inputRef = useRef<HTMLInputElement>(null);
 
-  // Keep input in sync if server round-trip updates the value
   useEffect(() => {
     if (state.success && inputRef.current) {
       inputRef.current.blur();
@@ -44,7 +44,7 @@ export function ProfileForm({ currentUsername }: Props) {
           className="bg-neutral-800 border-neutral-700 text-neutral-200 placeholder:text-neutral-500 focus-visible:ring-blue-600"
         />
         <p className="text-xs text-neutral-600">
-          This is the name shown on your dashboard greeting. Max 32 characters.
+          Shown on your dashboard greeting. Max 32 characters.
         </p>
       </div>
 
@@ -59,13 +59,13 @@ export function ProfileForm({ currentUsername }: Props) {
         </p>
       )}
 
-      <button
+      <Button
         type="submit"
         disabled={isPending}
-        className="w-full py-3 rounded-xl font-semibold text-sm transition-all duration-150 bg-blue-600 text-white hover:bg-blue-500 active:bg-blue-700 disabled:opacity-40 disabled:cursor-not-allowed"
+        className="w-full bg-blue-600 hover:bg-blue-500 text-white"
       >
         {isPending ? "Saving..." : "Save changes"}
-      </button>
+      </Button>
     </form>
   );
 }

--- a/src/components/sign-out-button.tsx
+++ b/src/components/sign-out-button.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useRouter } from "next/navigation";
 import { signOut } from "@/app/actions/profile";
 import { LogOut } from "lucide-react";
+import { Button } from "@/components/ui/button";
 
 export function SignOutButton() {
   async function handleSignOut() {
@@ -13,12 +13,14 @@ export function SignOutButton() {
   }
 
   return (
-    <button
+    <Button
+      type="button"
+      variant="outline"
       onClick={handleSignOut}
-      className="flex items-center gap-2 w-full px-4 py-3 rounded-xl text-sm font-medium text-red-400 bg-neutral-900 border border-neutral-800 hover:border-red-900 hover:bg-red-950/20 transition-colors"
+      className="w-full justify-start gap-3 bg-neutral-900 border-neutral-800 text-red-400 hover:bg-red-950/20 hover:border-red-900 hover:text-red-400"
     >
       <LogOut className="w-4 h-4" />
       Sign out
-    </button>
+    </Button>
   );
 }


### PR DESCRIPTION
## What changed
- Refactored the `ProfileForm` and `SignOutButton` components to use the `shadcn/ui` `Button` for consistent design system styling across the app.
- Reorganized the `/profile` page layout into distinct, logical sections, including a dedicated "Danger Zone" for the newly added account deletion feature and a section for password changes.
- Added a conditionally rendered link to the Admin Panel (`/admin`) within the profile settings. This link is only visible and accessible to users whose `is_admin` flag is true.
- Another update for entry 19 of my `prompt-log-enzoq.md`

## How to test
- Pull the branch locally and run `npm run dev`.
- Navigate to the `/profile` page as a standard, non-admin user.
- Verify the new UI layout: the `shadcn` button styling on the display name form and sign-out button, the password change section, and the "Danger Zone".
- Confirm that the link to the Admin Panel is **not** visible.
- Open Supabase, navigate to the `profiles` table, and set `is_admin = true` for your test user.
- Refresh the `/profile` page. The Admin Panel link should now appear. Click it to ensure it routes correctly to `/admin`.

## Checklist
- [x] Forked from dev
- [x] App runs without errors
- [x] No .env files committed
- [x] No console.log in code