### PR TITLE
[S4-DEV-05] db: add migration query used for implementing self-deletion of account

### DIFF
--- a/supabase/migrations/delete-own-account-function.sql
+++ b/supabase/migrations/delete-own-account-function.sql
@@ -1,0 +1,15 @@
+-- ============================================================
+-- Migration: Self-deletion RPC function
+-- Sprint: S4 | Task: S4-DEV-05
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.delete_own_account()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  DELETE FROM auth.users WHERE id = auth.uid();
+END;
+$$;


### PR DESCRIPTION
## What changed
- Added a database migration script to introduce the `delete_own_account()` Remote Procedure Call (RPC)
- Configured the function with `SECURITY DEFINER` privileges, securely allowing authenticated users to delete their own record directly from the `auth.users` table
- Restricted the deletion explicitly to `id = auth.uid()` to prevent any unauthorized cross-account deletions

## Checklist
- [x] Forked from dev
- [x] App runs without errors
- [x] No .env files committed
- [x] No console.log in code