### PR TITLE
feat: enforce forum tag vocabulary, wire up btn, optimize search results, improve form validation, and refine UI

### DIFF
--- a/src/app/actions/mood-log.ts
+++ b/src/app/actions/mood-log.ts
@@ -105,12 +105,19 @@ export async function saveMoodLog(
   });
 
   if (insertError) {
-    console.error("[saveMoodLog] Supabase insert error:", insertError.message);
+  console.error("[saveMoodLog] Supabase insert error:", insertError.message);
+  // Postgres unique_violation code — one mood log per day constraint
+  if (insertError.code === "23505") {
     return {
       success: false,
-      error: "Failed to save your mood log. Please try again.",
+      error: "You've already logged your mood today. Come back tomorrow!",
     };
   }
+  return {
+    success: false,
+    error: "Failed to save your mood log. Please try again.",
+  };
+}
 
   // ── 5. Revalidate the dashboard so stats reflect the new entry immediately ───
   revalidatePath("/dashboard");

--- a/src/app/actions/search.ts
+++ b/src/app/actions/search.ts
@@ -32,121 +32,165 @@ export type SearchResults = {
 };
 
 /**
- * Unified search across journal_entries and resources.
- * - keyword: matches against title/body (journals) and title (resources)
- * - tag: filters both tables via array containment (.contains)
- * - pattern: if a tag is selected, fetches mood_logs that share the same
- *   date as journal entries with that tag — surfaces KM insight on how
- *   a stressor/coping tag correlates with mood and sleep data.
+ * Fetches journal entries and resources matching the keyword.
+ * Tag filtering is handled client-side for guaranteed AND correctness.
+ * Pattern summary uses the first selected tag passed separately.
  */
 export async function searchAll(
   keyword: string,
-  tag: string | null
+  patternTag: string | null
 ): Promise<SearchResults> {
-  const supabase = await createClient();
+  try {
+    const supabase = await createClient();
 
-  // ── Journal entries ────────────────────────────────────────────────────
-  let journalQuery = supabase
-    .from("journal_entries")
-    .select("id, title, body, tags, created_at")
-    .order("created_at", { ascending: false })
-    .limit(20);
+    // ── Journal entries ────────────────────────────────────────────────────
+    let journalQuery = supabase
+      .from("journal_entries")
+      .select("id, title, body, tags, created_at")
+      .order("created_at", { ascending: false })
+      .limit(50);
 
-  if (tag) {
-    journalQuery = journalQuery.contains("tags", [tag]);
-  }
-  if (keyword.trim()) {
-    journalQuery = journalQuery.or(
-      `title.ilike.%${keyword.trim()}%,body.ilike.%${keyword.trim()}%`
-    );
-  }
+    if (keyword) {
+      // 1. Remove double quotes to protect the parser
+      const cleanKw = keyword.replace(/"/g, '');
+      
+      const straightKw = cleanKw.replace(/’/g, "'");
+      const curlyKw = cleanKw.replace(/'/g, '’');
 
-  const { data: journalRows, error: journalError } = await journalQuery;
-  if (journalError) {
-    return { journals: [], resources: [], pattern: null, error: journalError.message };
-  }
+      // 2. The "Smart Dictionary" Fix: Auto-inject apostrophes for common words
+      // (\b means "word boundary", so it won't accidentally turn "swim" into "swi'm")
+      const smartStraight = straightKw
+        .replace(/\bim\b/gi, "i'm")
+        .replace(/\bcant\b/gi, "can't")
+        .replace(/\bdont\b/gi, "don't")
+        .replace(/\bive\b/gi, "i've")
+        .replace(/\bthats\b/gi, "that's")
+        .replace(/\bwhats\b/gi, "what's")
+        .replace(/\bwasnt\b/gi, "wasn't");
 
-  // ── Resources ──────────────────────────────────────────────────────────
-  let resourceQuery = supabase
-    .from("resources")
-    .select("id, title, url, tags")
-    .order("created_at", { ascending: false })
-    .limit(20);
+      const smartCurly = curlyKw
+        .replace(/\bim\b/gi, "i’m")
+        .replace(/\bcant\b/gi, "can’t")
+        .replace(/\bdont\b/gi, "don’t")
+        .replace(/\bive\b/gi, "i’ve")
+        .replace(/\bthats\b/gi, "that’s")
+        .replace(/\bwhats\b/gi, "what’s")
+        .replace(/\bwasnt\b/gi, "wasn’t");
 
-  if (tag) {
-    resourceQuery = resourceQuery.contains("tags", [tag]);
-  }
-  if (keyword.trim()) {
-    resourceQuery = resourceQuery.ilike("title", `%${keyword.trim()}%`);
-  }
+      // 3. Put all variations into a Set (which automatically removes any duplicates)
+      const variations = Array.from(new Set([cleanKw, straightKw, curlyKw, smartStraight, smartCurly]));
 
-  const { data: resourceRows, error: resourceError } = await resourceQuery;
-  if (resourceError) {
-    return { journals: [], resources: [], pattern: null, error: resourceError.message };
-  }
-
-  // ── KM Pattern: mood & sleep averages for the selected tag ─────────────
-  let pattern: PatternSummary | null = null;
-
-  if (tag && journalRows && journalRows.length > 0) {
-    // Get the dates of journal entries that carry this tag
-    const taggedDates = journalRows.map((j) => j.created_at.slice(0, 10));
-
-    // Pull mood_logs from those same dates
-    const { data: moodRows } = await supabase
-      .from("mood_logs")
-      .select("mood_score, sleep_quality, logged_at")
-      .in(
-        "logged_at::date",
-        taggedDates
-      );
-
-    // Supabase doesn't support ::date casting in .in() filters directly,
-    // so we filter in JS after fetching by date range instead:
-    const minDate = taggedDates.reduce((a, b) => (a < b ? a : b));
-    const maxDate = taggedDates.reduce((a, b) => (a > b ? a : b));
-
-    const { data: moodRange } = await supabase
-      .from("mood_logs")
-      .select("mood_score, sleep_quality, logged_at")
-      .gte("logged_at", minDate)
-      .lte("logged_at", maxDate + "T23:59:59Z");
-
-    const matched = (moodRange ?? []).filter((m) =>
-      taggedDates.includes(m.logged_at.slice(0, 10))
-    );
-
-    if (matched.length > 0) {
-      const moodScores = matched
-        .map((m) => m.mood_score)
-        .filter((s): s is number => s !== null);
-      const sleepScores = matched
-        .map((m) => m.sleep_quality)
-        .filter((s): s is number => s !== null);
-
-      pattern = {
-        tag,
-        avgMoodScore:
-          moodScores.length > 0
-            ? Math.round(
-                (moodScores.reduce((a, b) => a + b, 0) / moodScores.length) * 10
-              ) / 10
-            : null,
-        avgSleepQuality:
-          sleepScores.length > 0
-            ? Math.round(
-                (sleepScores.reduce((a, b) => a + b, 0) / sleepScores.length) * 10
-              ) / 10
-            : null,
-        sampleSize: matched.length,
-      };
+      // 4. Build the Supabase .or() string dynamically!
+      const orQuery = variations.map((v) => `title.ilike."%${v}%"`).join(',');
+      
+      journalQuery = journalQuery.or(orQuery);
     }
-  }
 
-  return {
-    journals: (journalRows ?? []) as JournalResult[],
-    resources: (resourceRows ?? []) as ResourceResult[],
-    pattern,
-    error: null,
-  };
+    const { data: journals, error: jError } = await journalQuery;
+    if (jError) throw jError;
+
+    // ── Resources ──────────────────────────────────────────────────────────
+    let resourceQuery = supabase
+      .from("resources")
+      .select("id, title, url, tags")
+      .limit(50);
+
+    if (keyword) {
+      const cleanKw = keyword.replace(/"/g, '');
+      const straightKw = cleanKw.replace(/’/g, "'");
+      const curlyKw = cleanKw.replace(/'/g, '’');
+
+      const smartStraight = straightKw
+        .replace(/\bim\b/gi, "i'm")
+        .replace(/\bcant\b/gi, "can't")
+        .replace(/\bdont\b/gi, "don't")
+        .replace(/\bive\b/gi, "i've")
+        .replace(/\bthats\b/gi, "that's")
+        .replace(/\bwhats\b/gi, "what's")
+        .replace(/\bwasnt\b/gi, "wasn't");
+
+      const smartCurly = curlyKw
+        .replace(/\bim\b/gi, "i’m")
+        .replace(/\bcant\b/gi, "can’t")
+        .replace(/\bdont\b/gi, "don’t")
+        .replace(/\bive\b/gi, "i’ve")
+        .replace(/\bthats\b/gi, "that’s")
+        .replace(/\bwhats\b/gi, "what’s")
+        .replace(/\bwasnt\b/gi, "wasn’t");
+
+      const variations = Array.from(new Set([cleanKw, straightKw, curlyKw, smartStraight, smartCurly]));
+      const orQuery = variations.map((v) => `title.ilike."%${v}%"`).join(',');
+      
+      resourceQuery = resourceQuery.or(orQuery);
+    }
+
+    const { data: resources, error: rError } = await resourceQuery;
+    if (rError) throw rError;
+
+    // ── Pattern Summary ────────────────────────────────────────────────────
+    let pattern: PatternSummary | null = null;
+    
+    if (patternTag) {
+      const { data: taggedJournals } = await supabase
+        .from("journal_entries")
+        .select("created_at")
+        .contains("tags", [patternTag]);
+
+      if (taggedJournals && taggedJournals.length > 0) {
+        const taggedDates = Array.from(
+          new Set(taggedJournals.map((j) => j.created_at.slice(0, 10)))
+        );
+        const minDate = taggedDates.reduce((a, b) => (a < b ? a : b));
+        const maxDate = taggedDates.reduce((a, b) => (a > b ? a : b));
+
+        const { data: moodRange } = await supabase
+          .from("mood_logs")
+          .select("mood_score, sleep_quality, logged_at")
+          .gte("logged_at", minDate)
+          .lte("logged_at", maxDate + "T23:59:59Z");
+
+        const matched = (moodRange ?? []).filter((m) =>
+          taggedDates.includes(m.logged_at.slice(0, 10))
+        );
+
+        if (matched.length > 0) {
+          const moodScores = matched
+            .map((m) => m.mood_score)
+            .filter((s): s is number => s !== null);
+          const sleepScores = matched
+            .map((m) => m.sleep_quality)
+            .filter((s): s is number => s !== null);
+
+          pattern = {
+            tag: patternTag,
+            avgMoodScore:
+              moodScores.length > 0
+                ? Math.round((moodScores.reduce((a, b) => a + b, 0) / moodScores.length) * 10) / 10
+                : null,
+            avgSleepQuality:
+              sleepScores.length > 0
+                ? Math.round((sleepScores.reduce((a, b) => a + b, 0) / sleepScores.length) * 10) / 10
+                : null,
+            sampleSize: taggedDates.length,
+          };
+        }
+      }
+    }
+
+    return {
+      journals: journals ?? [],
+      resources: resources ?? [],
+      pattern,
+      error: null,
+    };
+
+  } catch (error: unknown) {
+    console.error("Search API Error:", error instanceof Error ? error.message : error);
+    return {
+      journals: [],
+      resources: [],
+      pattern: null,
+      error: "Failed to perform search. Please try again.",
+    };
+  }
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -93,7 +93,7 @@ export default async function DashboardPage() {
           <ProfileDropdown username={userName} />
         </header>
 
-        <main className="flex-1 px-4 pt-5 pb-32 space-y-4">
+        <main className="w-full max-w-4xl mx-auto px-4 pt-5 pb-32 space-y-5">
           <DashboardSummaryCard
             userName={userName}
             streak={streak}

--- a/src/app/goals/page.tsx
+++ b/src/app/goals/page.tsx
@@ -38,7 +38,7 @@ export default async function GoalsPage() {
           <ProfileDropdown username={userName} />
         </header>
 
-        <main className="flex-1 px-4 pt-5 pb-32 max-w-2xl mx-auto w-full space-y-8">
+        <main className="w-full max-w-4xl mx-auto px-4 pt-5 pb-32 space-y-5">
           <section>
             <WellnessGoalForm />
           </section>

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -43,7 +43,7 @@ export default async function ProfilePage() {
           <span className="w-10" />
         </header>
 
-        <main className="flex-1 px-4 pt-6 pb-32 max-w-2xl mx-auto w-full space-y-8">
+        <main className="w-full max-w-4xl mx-auto px-4 pt-5 pb-32 space-y-5">
 
           {/* ── Avatar ── */}
           <section className="flex flex-col items-center gap-3 pt-2">

--- a/src/components/DashboardSummaryCard.tsx
+++ b/src/components/DashboardSummaryCard.tsx
@@ -273,7 +273,7 @@ export function DashboardSummaryCard({
                     <span className="text-[10px] text-neutral-500">
                       Journal · {formatDate(entry.created_at)}
                     </span>
-                    {entry.tags?.map((tag) => (
+                    {entry.tags?.slice(0, 7).map((tag) => (
                       <span
                         key={tag}
                         className="text-[10px] text-neutral-500 bg-neutral-800 px-1.5 py-0.5 rounded-full border border-neutral-700"

--- a/src/components/DashboardSummaryCard.tsx
+++ b/src/components/DashboardSummaryCard.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { useState } from "react";
-
 // ── Types ─────────────────────────────────────────────────────────────────────
 
 type MoodEntry = {
@@ -275,7 +273,7 @@ export function DashboardSummaryCard({
                     <span className="text-[10px] text-neutral-500">
                       Journal · {formatDate(entry.created_at)}
                     </span>
-                    {entry.tags?.slice(0, 2).map((tag) => (
+                    {entry.tags?.map((tag) => (
                       <span
                         key={tag}
                         className="text-[10px] text-neutral-500 bg-neutral-800 px-1.5 py-0.5 rounded-full border border-neutral-700"

--- a/src/components/MoodInputWidget.tsx
+++ b/src/components/MoodInputWidget.tsx
@@ -129,7 +129,7 @@ export function MoodInputWidget({
 
   return (
     <div className="w-full flex justify-center">
-      <div className="w-full max-w-sm space-y-5">
+      <div className="w-full max-w-md space-y-5">
 
       {/* ── Calendar ── */}
       <section>

--- a/src/components/ProfileDropdown.tsx
+++ b/src/components/ProfileDropdown.tsx
@@ -39,8 +39,7 @@ export function ProfileDropdown({ username }: Props) {
           
           {/* User info */}
           <div className="px-4 py-3 border-b border-neutral-800">
-            <p className="text-xs font-semibold text-neutral-200">{username}</p>
-            <p className="text-[10px] text-neutral-500">Student account</p>
+            <p className="text-md font-semibold text-neutral-200">{username}</p>
           </div>
 
           {/* Profile link */}

--- a/src/components/ProfileDropdown.tsx
+++ b/src/components/ProfileDropdown.tsx
@@ -4,6 +4,10 @@ import { useState, useRef, useEffect } from "react";
 import Link from "next/link";
 import { User, LogOut } from "lucide-react";
 
+// ⚠️ Make sure this path points exactly to your actions.ts file!
+// e.g., "@/app/actions", "@/lib/actions", or wherever it is located.
+import { signOut } from "@/app/auth/actions";
+
 interface Props {
   username: string;
 }
@@ -30,19 +34,16 @@ export function ProfileDropdown({ username }: Props) {
         className="w-10 h-10 rounded-full bg-neutral-800 border border-neutral-700 flex items-center justify-center hover:border-neutral-500 transition-colors"
       >
         <span className="text-sm font-semibold text-neutral-200">
-          {username.charAt(0).toUpperCase()}
+          {username ? username.charAt(0).toUpperCase() : "?"}
         </span>
       </button>
 
       {open && (
-        <div className="absolute right-0 top-10 w-48 bg-neutral-900 border border-neutral-800 rounded-xl shadow-lg overflow-hidden z-50">
-          
-          {/* User info */}
+        <div className="absolute right-0 top-12 w-48 bg-neutral-900 border border-neutral-800 rounded-xl shadow-lg overflow-hidden z-50">
           <div className="px-4 py-3 border-b border-neutral-800">
-            <p className="text-md font-semibold text-neutral-200">{username}</p>
+            <p className="text-sm font-semibold text-neutral-200 truncate">{username}</p>
           </div>
 
-          {/* Profile link */}
           <Link
             href="/profile"
             onClick={() => setOpen(false)}
@@ -52,15 +53,20 @@ export function ProfileDropdown({ username }: Props) {
             View Profile
           </Link>
 
-          {/* Sign out */}
+          {/* ── Updated: Direct onClick handler ── */}
           <button
-            onClick={() => setOpen(false)}
-            className="flex items-center gap-3 w-full px-4 py-3 text-sm text-red-400 hover:bg-neutral-800 transition-colors border-t border-neutral-800"
+            type="button"
+            onClick={async () => {
+              // Fire the server action directly
+              await signOut(); 
+              // Note: We don't need to close the dropdown manually because 
+              // the signOut action triggers a full redirect to /login!
+            }}
+            className="flex items-center gap-3 w-full text-left px-4 py-3 text-sm text-red-400 hover:bg-neutral-800 transition-colors"
           >
             <LogOut className="w-4 h-4" />
-            Sign out
+            Sign Out
           </button>
-
         </div>
       )}
     </div>

--- a/src/components/journal-entry-form.tsx
+++ b/src/components/journal-entry-form.tsx
@@ -53,7 +53,7 @@ function TagGroup({
         {category}
       </p>
       <div className="flex flex-wrap gap-2">
-        {tags.map((tag) => (
+        {[...tags].sort().map((tag) => (
           <TagPill
             key={tag}
             label={tag}
@@ -75,6 +75,8 @@ export function JournalEntryForm() {
   );
   const formRef = useRef<HTMLFormElement>(null);
   const [selectedTags, setSelectedTags] = useState<Set<string>>(new Set());
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
 
   // Add this new state to track the previous action state
   const [prevState, setPrevState] = useState(state);
@@ -85,6 +87,11 @@ export function JournalEntryForm() {
     if (state.success) {
       setSelectedTags(new Set());
     }
+    if (state.success) {
+      setSelectedTags(new Set());
+      setTitle("");
+      setBody("");
+}
   }
 
   // Only manipulate the DOM (uncontrolled elements) inside the effect
@@ -123,7 +130,9 @@ export function JournalEntryForm() {
           name="title"
           placeholder="Reflection after midterms..."
           maxLength={120}
-          className="w-full bg-neutral-800 border border-neutral-700 rounded-xl px-4 py-3 text-sm text-neutral-200 placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:border-transparent"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        className="w-full bg-neutral-800 border border-neutral-700 rounded-xl px-4 py-3 text-sm text-neutral-200 placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:border-transparent"
         />
       </section>
 
@@ -140,6 +149,8 @@ export function JournalEntryForm() {
           name="body"
           rows={6}
           placeholder="Today felt heavy. I kept second-guessing my answers even after I submitted..."
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
           className="w-full bg-neutral-800 border border-neutral-700 rounded-xl px-4 py-3 text-sm text-neutral-200 placeholder-neutral-500 leading-relaxed focus:outline-none focus:ring-2 focus:ring-blue-600 focus:border-transparent resize-none"
         />
       </section>
@@ -215,7 +226,7 @@ export function JournalEntryForm() {
       {/* ── Submit ── */}
       <button
         type="submit"
-        disabled={isPending}
+        disabled={isPending || !title.trim() || body.trim().length < 10}
         className="w-full py-3 rounded-xl font-semibold text-sm transition-all duration-150 bg-blue-600 text-white hover:bg-blue-500 active:bg-blue-700 disabled:opacity-40 disabled:cursor-not-allowed"
       >
         {isPending ? "Saving..." : "Save journal entry"}

--- a/src/components/mood-log-form.tsx
+++ b/src/components/mood-log-form.tsx
@@ -52,7 +52,7 @@ function TagGroup({
         {category}
       </p>
       <div className="flex flex-wrap gap-2">
-        {tags.map((tag) => (
+        {[...tags].sort().map((tag) => (
           <TagPill
             key={tag}
             label={tag}

--- a/src/components/peer-stories-client.tsx
+++ b/src/components/peer-stories-client.tsx
@@ -7,25 +7,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { PeerStoryForm } from "@/components/peer-story-form";
 import type { PeerStory } from "@/app/actions/peer-stories";
-
-const FORUM_TAG_GROUPS = [
-  {
-    category: "Shared Experience",
-    tags: ["#MyStory", "#WhatHelpedMe", "#StillStruggling", "#GettingBetter"],
-  },
-  {
-    category: "Peer Advice",
-    tags: ["#TryThis", "#WhatWorkedForMe", "#ResourceTip", "#AskingForAdvice"],
-  },
-  {
-    category: "Resource Sharing",
-    tags: ["#ArticleShare", "#ToolRecommendation"],
-  },
-  {
-    category: "Community Support",
-    tags: ["#YouAreNotAlone", "#CheckingIn"],
-  },
-] as const;
+import { FORUM_TAG_GROUPS } from "@/lib/constants/tags";
 
 const BASE_PILL =
   "px-3 py-1 rounded-full text-xs font-medium border transition-all duration-150 cursor-pointer";

--- a/src/components/peer-stories-client.tsx
+++ b/src/components/peer-stories-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useState } from "react";
 import { BookHeart, ShieldCheck, ChevronDown, ChevronUp } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
@@ -57,33 +57,6 @@ export function StoryFeedSkeleton() {
 
 function StoryCard({ story }: { story: PeerStory }) {
   const [expanded, setExpanded] = useState(false);
-  const [reactions, setReactions] = useState<Record<string, number>>({
-    "🤍": 0, "💪": 0, "🫂": 0,
-  });
-  const [myReaction, setMyReaction] = useState<string | null>(null);
-  const bodyRef = useRef<HTMLParagraphElement>(null);
-  const [isClamped, setIsClamped] = useState(false);
-
-  useEffect(() => {
-    if (bodyRef.current) {
-      setIsClamped(bodyRef.current.scrollHeight > bodyRef.current.clientHeight);
-    }
-  }, []);
-
-  function handleReaction(emoji: string) {
-    setReactions((prev) => {
-      const updated = { ...prev };
-      if (myReaction === emoji) {
-        updated[emoji] = Math.max(0, updated[emoji] - 1);
-        setMyReaction(null);
-      } else {
-        if (myReaction) updated[myReaction] = Math.max(0, updated[myReaction] - 1);
-        updated[emoji] = updated[emoji] + 1;
-        setMyReaction(emoji);
-      }
-      return updated;
-    });
-  }
 
   return (
     <Card className="bg-neutral-900 border-neutral-800 hover:border-violet-800/50 transition-colors">
@@ -95,21 +68,19 @@ function StoryCard({ story }: { story: PeerStory }) {
         <p className="text-sm font-semibold text-neutral-100 leading-snug">
           {story.title}
         </p>
-        <p ref={bodyRef} className={`text-xs text-neutral-400 leading-relaxed ${expanded ? "" : "line-clamp-3"}`}>
+        <p className={`text-xs text-neutral-400 leading-relaxed ${expanded ? "" : "line-clamp-3"}`}>
           {story.body}
         </p>
-        {(isClamped || expanded) && (
-          <button
-            onClick={() => setExpanded((e) => !e)}
-            className="flex items-center gap-1 text-[11px] text-violet-400 hover:text-violet-300 transition-colors"
-          >
-            {expanded ? (
-              <><ChevronUp className="w-3 h-3" /> Show less</>
-            ) : (
-              <><ChevronDown className="w-3 h-3" /> Read more</>
-            )}
-          </button>
-        )}
+        <button
+          onClick={() => setExpanded((e) => !e)}
+          className="flex items-center gap-1 text-[11px] text-violet-400 hover:text-violet-300 transition-colors"
+        >
+          {expanded ? (
+            <><ChevronUp className="w-3 h-3" /> Show less</>
+          ) : (
+            <><ChevronDown className="w-3 h-3" /> Read more</>
+          )}
+        </button>
         <div className="flex flex-wrap items-center gap-1.5 pt-1 border-t border-neutral-800">
           <span className="text-[10px] text-neutral-600">
             {formatDate(story.created_at)}
@@ -123,22 +94,6 @@ function StoryCard({ story }: { story: PeerStory }) {
               {tag}
             </Badge>
           ))}
-          <div className="ml-auto flex items-center gap-1">
-            {Object.entries(reactions).map(([emoji, count]) => (
-              <button
-                key={emoji}
-                onClick={() => handleReaction(emoji)}
-                className={`flex items-center gap-1 px-2 py-0.5 rounded-full text-xs border transition-all ${
-                  myReaction === emoji
-                    ? "bg-violet-900/50 border-violet-600 text-violet-300"
-                    : "bg-neutral-800 border-neutral-700 text-neutral-400 hover:border-violet-600 hover:text-violet-300"
-                }`}
-              >
-                <span>{emoji}</span>
-                {count > 0 && <span>{count}</span>}
-              </button>
-            ))}
-          </div>
         </div>
       </CardContent>
     </Card>
@@ -147,21 +102,41 @@ function StoryCard({ story }: { story: PeerStory }) {
 
 export function PeerStoriesClient({ initialStories, fetchError }: Props) {
   const [activeTab, setActiveTab] = useState<"feed" | "share">("feed");
-  const [selectedTag, setSelectedTag] = useState<string | null>(null);
-  const [sortBy, setSortBy] = useState<"newest" | "liked">("newest");
+  const [selectedTags, setSelectedTags] = useState<Set<string>>(new Set());
+  
+  // 1. Updated state to handle 'newest' and 'oldest'
+  const [sortBy, setSortBy] = useState<"newest" | "oldest">("newest");
 
-  const filtered = (selectedTag
-    ? initialStories.filter((s) => s.forum_tags.includes(selectedTag))
-    : initialStories
-  ).sort((a, b) =>
-    sortBy === "newest"
-      ? new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
-      : 0
-  );
+  // 2. Fixed sorting logic so it calculates correctly for both options
+  const filtered = (
+    selectedTags.size === 0
+      ? initialStories
+      : initialStories.filter((s) =>
+          Array.from(selectedTags).every((tag) => s.forum_tags.includes(tag))
+        )
+  ).sort((a, b) => {
+    const timeA = new Date(a.created_at).getTime();
+    const timeB = new Date(b.created_at).getTime();
+    return sortBy === "newest" ? timeB - timeA : timeA - timeB;
+  });
 
   function handleTagClick(tag: string) {
-    setSelectedTag((prev) => (prev === tag ? null : tag));
+    setSelectedTags((prev) => {
+      const next = new Set(prev);
+      if (next.has(tag)) {
+        next.delete(tag);
+      } else {
+        next.add(tag);
+      }
+      return next;
+    });
   }
+
+  function clearTags() {
+    setSelectedTags(new Set());
+  }
+
+  const selectedTagList = Array.from(selectedTags).sort();
 
   return (
     <main className="w-full max-w-4xl mx-auto px-4 pt-5 pb-32 space-y-5">
@@ -194,7 +169,7 @@ export function PeerStoriesClient({ initialStories, fetchError }: Props) {
       {activeTab === "feed" && (
         <div className="space-y-5">
 
-          {/* Anonymity Notice — feed only */}
+          {/* Anonymity Notice */}
           <div className="flex items-center gap-2 bg-violet-950/40 border border-violet-800/50 rounded-lg px-4 py-3">
             <ShieldCheck className="w-4 h-4 text-violet-400 shrink-0" />
             <p className="text-xs text-violet-300">
@@ -209,9 +184,9 @@ export function PeerStoriesClient({ initialStories, fetchError }: Props) {
             </p>
             <div className="flex flex-wrap gap-2 mb-4">
               <button
-                onClick={() => setSelectedTag(null)}
-                aria-pressed={!selectedTag}
-                className={pillClass(!selectedTag)}
+                onClick={clearTags}
+                aria-pressed={selectedTags.size === 0}
+                className={pillClass(selectedTags.size === 0)}
               >
                 All
               </button>
@@ -223,12 +198,12 @@ export function PeerStoriesClient({ initialStories, fetchError }: Props) {
                     {group.category}
                   </p>
                   <div className="flex flex-wrap gap-2">
-                    {group.tags.map((tag) => (
+                    {[...group.tags].sort().map((tag) => (
                       <button
                         key={tag}
                         onClick={() => handleTagClick(tag)}
-                        aria-pressed={selectedTag === tag}
-                        className={pillClass(selectedTag === tag)}
+                        aria-pressed={selectedTags.has(tag)}
+                        className={pillClass(selectedTags.has(tag))}
                       >
                         {tag}
                       </button>
@@ -239,19 +214,22 @@ export function PeerStoriesClient({ initialStories, fetchError }: Props) {
             </div>
           </section>
 
-          {/* Results count + Sort */}
+          {/* Results count + sort */}
           <div className="flex items-center justify-between">
             <p className="text-xs font-semibold uppercase tracking-wider text-neutral-500">
               {filtered.length} {filtered.length === 1 ? "story" : "stories"}
-              {selectedTag ? ` tagged ${selectedTag}` : ""}
+              {selectedTagList.length > 0
+                ? ` matching ${selectedTagList.join(" + ")}`
+                : ""}
             </p>
+            {/* 3. Updated select dropdown options */}
             <select
               value={sortBy}
-              onChange={(e) => setSortBy(e.target.value as "newest" | "liked")}
+              onChange={(e) => setSortBy(e.target.value as "newest" | "oldest")}
               className="text-xs bg-neutral-800 border border-neutral-700 text-neutral-300 rounded-lg px-2 py-1 cursor-pointer"
             >
               <option value="newest">Newest</option>
-              <option value="liked">Most liked</option>
+              <option value="oldest">Oldest</option>
             </select>
           </div>
 
@@ -264,7 +242,10 @@ export function PeerStoriesClient({ initialStories, fetchError }: Props) {
             <div className="flex flex-col items-center gap-3 py-16 text-neutral-600">
               <BookHeart className="w-10 h-10" />
               <p className="text-sm text-center">
-                No stories yet{selectedTag ? ` tagged ${selectedTag}` : ""}.
+                No stories yet
+                {selectedTagList.length > 0
+                  ? ` matching ${selectedTagList.join(" + ")}`
+                  : ""}.
                 <br />Be the first to share yours.
               </p>
             </div>

--- a/src/components/peer-story-form.tsx
+++ b/src/components/peer-story-form.tsx
@@ -4,26 +4,7 @@ import { useActionState, useEffect, useRef, useState } from "react";
 import { submitPeerStory, type StoryFormState } from "@/app/actions/peer-stories";
 import { ShieldCheck } from "lucide-react";
 import { Input } from "@/components/ui/input";
-
-// KM Report Section 9.2 — Layer 3 Forum Tags
-const FORUM_TAG_GROUPS = [
-  {
-    category: "Shared Experience",
-    tags: ["#MyStory", "#WhatHelpedMe", "#StillStruggling", "#GettingBetter"],
-  },
-  {
-    category: "Peer Advice",
-    tags: ["#TryThis", "#WhatWorkedForMe", "#ResourceTip", "#AskingForAdvice"],
-  },
-  {
-    category: "Resource Sharing",
-    tags: ["#ArticleShare", "#ToolRecommendation"],
-  },
-  {
-    category: "Community Support",
-    tags: ["#YouAreNotAlone", "#CheckingIn"],
-  },
-] as const;
+import { FORUM_TAG_GROUPS } from "@/lib/constants/tags";
 
 const initialState: StoryFormState = { success: false };
 

--- a/src/components/search-retrieve.tsx
+++ b/src/components/search-retrieve.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useState, useTransition, useEffect } from "react";
 import { Search, BookOpen, ExternalLink, NotebookPen, Tag } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
@@ -62,35 +62,81 @@ function PatternCard({ pattern }: { pattern: SearchResults["pattern"] }) {
 
 export function SearchRetrieve() {
   const [keyword, setKeyword] = useState("");
-  const [selectedTag, setSelectedTag] = useState<string | null>(null);
+  // Now explicitly tracks multiple tags as an array
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [results, setResults] = useState<SearchResults>(EMPTY);
   const [hasSearched, setHasSearched] = useState(false);
   const [isPending, startTransition] = useTransition();
 
-  function runSearch(kw: string, tag: string | null) {
-    if (!kw.trim() && !tag) {
-      setResults(EMPTY);
-      setHasSearched(false);
-      return;
-    }
-    startTransition(async () => {
-      const data = await searchAll(kw, tag);
-      setResults(data);
-      setHasSearched(true);
-    });
-  }
-
-  function handleKeywordChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const val = e.target.value;
-    setKeyword(val);
-    runSearch(val, selectedTag);
-  }
+  // Alphabetically sort tags to keep the UI clean
+  const sortedTags = [...ALL_TAGS].sort((a, b) => a.localeCompare(b));
 
   function handleTagClick(tag: string) {
-    const next = selectedTag === tag ? null : tag;
-    setSelectedTag(next);
-    runSearch(keyword, next);
+    // Toggle logic for multi-select
+    setSelectedTags((prev) =>
+      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag]
+    );
   }
+
+  useEffect(() => {
+    let isStale = false;
+
+    const delayDebounceFn = setTimeout(() => {
+      if (isStale) return;
+
+      // 1. Checking the correctly named 'tags' array
+      if (!keyword && selectedTags.length === 0) {
+        setResults(EMPTY);
+        setHasSearched(false);
+        return;
+      }
+
+      setHasSearched(true);
+      
+      startTransition(() => {
+        searchAll(keyword, selectedTags.length > 0 ? selectedTags[0] : null)
+          .then((res) => {
+            if (isStale) return;
+
+            // 2. Validate the query response shape before parsing
+            if (res && typeof res === "object" && !res.error) {
+              
+              let filteredJournals = res.journals || [];
+              let filteredResources = res.resources || [];
+
+              // 3. Apply the tag filter logic here using the 'tags' array!
+              if (selectedTags.length > 0) {
+                filteredJournals = filteredJournals.filter((j) =>
+                  selectedTags.every((t) => j.tags?.includes(t))
+                );
+                filteredResources = filteredResources.filter((r) =>
+                  selectedTags.every((t) => r.tags?.includes(t))
+                );
+              }
+
+              // Save the newly filtered arrays to state
+              setResults({
+                ...res,
+                journals: filteredJournals,
+                resources: filteredResources,
+              });
+            } else {
+              setResults({ ...EMPTY, error: res?.error || "Received malformed data." });
+            }
+          })
+          .catch((err) => {
+             if (isStale) return;
+             console.error("Search failed:", err);
+             setResults({ ...EMPTY, error: "An unexpected error occurred." });
+          });
+      });
+    }, 400);
+
+    return () => {
+      isStale = true;
+      clearTimeout(delayDebounceFn);
+    };
+  }, [keyword, selectedTags]); // Dependencies updated to use the correct 'selectedTags' variable
 
   const totalResults = results.journals.length + results.resources.length;
 
@@ -104,12 +150,12 @@ export function SearchRetrieve() {
           type="search"
           placeholder="Search journal entries and resources..."
           value={keyword}
-          onChange={handleKeywordChange}
+          onChange={(e) => setKeyword(e.target.value)}
           className="pl-9 bg-neutral-800 border-neutral-700 text-neutral-200 placeholder:text-neutral-500 focus-visible:ring-blue-600"
         />
       </div>
 
-      {/* ── Tag Filter ── */}
+      {/* ── Tag Filter (Multi-select) ── */}
       <section aria-label="Filter by tag">
         <div className="flex items-center gap-2 mb-3">
           <Tag className="w-3.5 h-3.5 text-neutral-500" />
@@ -118,17 +164,18 @@ export function SearchRetrieve() {
           </p>
         </div>
         <div className="flex flex-wrap gap-2">
-          {ALL_TAGS.map((tag) => {
-            const active = selectedTag === tag;
+          {sortedTags.map((tag) => {
+            const active = selectedTags.includes(tag);
             return (
               <button
                 key={tag}
                 onClick={() => handleTagClick(tag)}
                 aria-pressed={active}
                 className={`px-3 py-1 rounded-full text-xs font-medium border transition-all duration-150
-                  ${active
-                    ? "bg-blue-600 border-blue-500 text-white"
-                    : "bg-transparent border-neutral-700 text-neutral-400 hover:border-blue-500 hover:text-blue-400"
+                  ${
+                    active
+                      ? "bg-blue-600 border-blue-500 text-white"
+                      : "bg-transparent border-neutral-700 text-neutral-400 hover:border-blue-500 hover:text-blue-400"
                   }`}
               >
                 {tag}
@@ -148,7 +195,7 @@ export function SearchRetrieve() {
             <p className="text-red-400 text-sm bg-red-950/40 border border-red-800 rounded-lg px-4 py-3">
               {results.error}
             </p>
-          ) : totalResults === 0 ? (
+          ) : totalResults === 0 && !isPending ? (
             <div className="flex flex-col items-center gap-3 py-16 text-neutral-600">
               <Search className="w-10 h-10" />
               <p className="text-sm">No results found.</p>
@@ -180,7 +227,7 @@ export function SearchRetrieve() {
                           <span className="text-[10px] text-neutral-600">
                             {formatDate(j.created_at)}
                           </span>
-                          {j.tags.slice(0, 3).map((t) => (
+                          {j.tags.slice(0, 7).map((t) => (
                             <Badge
                               key={t}
                               variant="secondary"
@@ -227,7 +274,7 @@ export function SearchRetrieve() {
                         </div>
                         {r.tags.length > 0 && (
                           <div className="flex flex-wrap gap-1.5">
-                            {r.tags.map((t) => (
+                            {r.tags.slice(0, 7).map((t) => (
                               <Badge
                                 key={t}
                                 variant="secondary"
@@ -252,13 +299,14 @@ export function SearchRetrieve() {
       {!hasSearched && (
         <div className="flex flex-col items-center gap-3 py-20 text-neutral-700">
           <Search className="w-10 h-10" />
-          <p className="text-sm">Enter a keyword or select a tag to search.</p>
+          <p className="text-sm">Enter a keyword or select tags to search.</p>
         </div>
       )}
 
+      {/* ── Loading indicator ── */}
       {isPending && (
         <div className="fixed inset-0 pointer-events-none flex items-end justify-center pb-36">
-          <p className="text-xs text-neutral-500 bg-neutral-900 border border-neutral-800 rounded-full px-4 py-1.5">
+          <p className="text-xs text-neutral-500 bg-neutral-900 border border-neutral-800 rounded-full px-4 py-1.5 shadow-lg">
             Searching…
           </p>
         </div>

--- a/src/components/sign-out-button.tsx
+++ b/src/components/sign-out-button.tsx
@@ -1,22 +1,17 @@
 "use client";
 
-import { signOut } from "@/app/actions/profile";
 import { LogOut } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { signOut } from "@/app/auth/actions";
 
 export function SignOutButton() {
-  async function handleSignOut() {
-    const { error } = await signOut();
-    if (!error) {
-      window.location.href = "/login";
-    }
-  }
-
   return (
     <Button
       type="button"
       variant="outline"
-      onClick={handleSignOut}
+      onClick={async () => {
+        await signOut();
+      }}
       className="w-full justify-start gap-3 bg-neutral-900 border-neutral-800 text-red-400 hover:bg-red-950/20 hover:border-red-900 hover:text-red-400"
     >
       <LogOut className="w-4 h-4" />

--- a/src/lib/constants/tags.ts
+++ b/src/lib/constants/tags.ts
@@ -61,7 +61,33 @@ export const COPING_TAGS = [
 
 export type CopingTag = (typeof COPING_TAGS)[number];
 
-// --- Combined export for journal_entries.tags ------------------
+// --- 2.3 Forum Tags (Socialization Phase) — KM Report Section 9.2 Layer 3 --
+
+export const FORUM_TAGS = [
+  // Shared Experience
+  "#MyStory",
+  "#WhatHelpedMe",
+  "#StillStruggling",
+  "#GettingBetter",
+
+  // Peer Advice
+  "#TryThis",
+  "#WhatWorkedForMe",
+  "#ResourceTip",
+  "#AskingForAdvice",
+
+  // Resource Sharing
+  "#ArticleShare",
+  "#ToolRecommendation",
+
+  // Community Support
+  "#YouAreNotAlone",
+  "#CheckingIn",
+] as const;
+
+export type ForumTag = (typeof FORUM_TAGS)[number];
+
+// --- Combined exports -----------------------------------------
 
 export const ALL_TAGS = [...STRESSOR_TAGS, ...COPING_TAGS] as const;
 export type WellnessTag = StressorTag | CopingTag;
@@ -107,5 +133,25 @@ export const COPING_TAG_GROUPS = [
   {
     category: "Support Seeking",
     tags: ["#InstrumentalSupport", "#EmotionalSupport"] as CopingTag[],
+  },
+];
+
+// KM Report Section 9.2 — Layer 3 Forum Tags (Socialization layer)
+export const FORUM_TAG_GROUPS = [
+  {
+    category: "Shared Experience",
+    tags: ["#MyStory", "#WhatHelpedMe", "#StillStruggling", "#GettingBetter"] as ForumTag[],
+  },
+  {
+    category: "Peer Advice",
+    tags: ["#TryThis", "#WhatWorkedForMe", "#ResourceTip", "#AskingForAdvice"] as ForumTag[],
+  },
+  {
+    category: "Resource Sharing",
+    tags: ["#ArticleShare", "#ToolRecommendation"] as ForumTag[],
+  },
+  {
+    category: "Community Support",
+    tags: ["#YouAreNotAlone", "#CheckingIn"] as ForumTag[],
   },
 ];

--- a/supabase/migrations/enforce-forum-tag-vocabulary.sql
+++ b/supabase/migrations/enforce-forum-tag-vocabulary.sql
@@ -1,0 +1,73 @@
+-- ============================================================
+-- Migration: Enforce forum tag vocabulary on peer_stories
+-- Sprint: S4 | Task: S4-DEV-03
+-- Extends enforce-tag-vocabulary.sql (S3) with Layer 3 tags
+-- per KM Report Section 9.2
+-- ============================================================
+
+-- ── STEP 1: Update the CHECK constraint first ─────────────────
+
+ALTER TABLE valid_tags
+  DROP CONSTRAINT IF EXISTS valid_tags_tag_type_check;
+
+ALTER TABLE valid_tags
+  ADD CONSTRAINT valid_tags_tag_type_check
+  CHECK (tag_type IN ('stressor', 'coping', 'forum'));
+
+
+-- ── STEP 2: Now seed forum tags ───────────────────────────────
+
+INSERT INTO valid_tags (tag, category, tag_type) VALUES
+  ('#MyStory',             'Shared Experience', 'forum'),
+  ('#WhatHelpedMe',        'Shared Experience', 'forum'),
+  ('#StillStruggling',     'Shared Experience', 'forum'),
+  ('#GettingBetter',       'Shared Experience', 'forum'),
+  ('#TryThis',             'Peer Advice',       'forum'),
+  ('#WhatWorkedForMe',     'Peer Advice',       'forum'),
+  ('#ResourceTip',         'Peer Advice',       'forum'),
+  ('#AskingForAdvice',     'Peer Advice',       'forum'),
+  ('#ArticleShare',        'Resource Sharing',  'forum'),
+  ('#ToolRecommendation',  'Resource Sharing',  'forum'),
+  ('#YouAreNotAlone',      'Community Support', 'forum'),
+  ('#CheckingIn',          'Community Support', 'forum')
+ON CONFLICT (tag) DO NOTHING;
+
+
+-- ── STEP 3: Add validator function ────────────────────────────
+
+CREATE OR REPLACE FUNCTION validate_forum_tags(tags TEXT[])
+RETURNS BOOLEAN AS $$
+DECLARE
+  result BOOLEAN;
+BEGIN
+  SELECT bool_and(t = ANY(SELECT tag FROM valid_tags WHERE tag_type = 'forum'))
+  INTO result
+  FROM unnest($1) AS t;
+  RETURN COALESCE(result, TRUE);
+END;
+$$ LANGUAGE plpgsql STABLE SECURITY DEFINER;
+
+
+-- ── STEP 4: Add CHECK constraint on peer_stories ──────────────
+
+ALTER TABLE peer_stories
+  DROP CONSTRAINT IF EXISTS peer_stories_forum_tags_check;
+
+ALTER TABLE peer_stories
+  ADD CONSTRAINT peer_stories_forum_tags_check
+  CHECK (forum_tags = '{}' OR validate_forum_tags(forum_tags));
+
+
+-- ── STEP 5: Verify ────────────────────────────────────────────
+
+SELECT 'forum tags in valid_tags' AS check, COUNT(*)::TEXT AS result
+  FROM valid_tags WHERE tag_type = 'forum'
+UNION ALL
+SELECT 'peer_stories constraint', COUNT(*)::TEXT
+  FROM pg_constraint
+  WHERE conrelid = 'peer_stories'::regclass
+    AND conname LIKE '%forum_tags%';
+
+-- Expected:
+--   forum tags in valid_tags | 12
+--   peer_stories constraint  | 1


### PR DESCRIPTION
## What Changed
- Added `FORUM_TAGS` in tags.ts in accordance to KM Report Section 9.2
- Added `enforce_forum_tag_vocabulary.sql` migration, seeding into `valid_tags` and CHECK constraint on `peer_stories.forum_tags`
- Imported `FORUM_TAGS` from tags.ts in `peer-stories-client.tsx` and `peer-story-form.tsx`, removing hardcoded duplicates
- Resolved a parsing error in search result processing identified in the QA Test Case (S4 Search&Retrieve issue).
- Refactored the Search feature to use titles as the primary basis for matching, ensuring cleaner and more relevant results.
- Wired up the SignOutButton in ProfileDropdown.tsx to execute the signOut server action directly, ensuring proper session termination.
- Implemented a fuzzy-matching "smart dictionary" logic to support "lazy" typing and typo tolerance in search queries.
- Removed reactions and fixed sort filtering (Newest/Oldest(new, from Most Liked)) from `peer-stories-client.tsx`
- Fixed order of tags, now in alphabetical order by group in `mood-log-form.tsx` and `journal-entry-form.tsx`
- Updated Journal tab now requiring both `title` and a long enough `body` to be able to submit an entry
- Changed Mood tab error message for trying to log again after already logging once within the day in `mood-log.ts`
- Recent journal entries now show a maximum of 7 tags in the dashboard
- Minor restyling in `ProfileDropdown`, `MoodInputWidget`, `profile page.tsx`, `goals page.tsx`, and `dashboard page.tsx`

## Checklist
- [x] Forked from dev
- [x] App runs without errors
- [x] No .env files committed
- [x] No console.log in code