### PR TITLE
feat: add skeleton components for all pages

### DIFF
--- a/src/app/dashboard/loading.tsx
+++ b/src/app/dashboard/loading.tsx
@@ -1,0 +1,26 @@
+import { DashboardSkeleton } from "@/components/DashboardSkeleton";
+import BottomNav from "@/components/BottomNav";
+import { ProfileDropdown } from "@/components/ProfileDropdown";
+
+export default function DashboardLoading() {
+  return (
+    <div className="min-h-screen bg-neutral-950 text-neutral-100">
+      <div className="mx-auto w-full max-w-md md:max-w-7xl min-h-screen flex flex-col relative border-x border-neutral-800/60">
+
+        <header className="sticky top-0 z-10 bg-neutral-950/90 backdrop-blur-md flex items-center justify-between px-4 py-4 border-b border-neutral-800">
+          <span className="w-10" />
+          <h1 className="text-base font-semibold text-neutral-100 text-center">Dashboard</h1>
+          {/* Send an empty string or generic placeholder while loading */}
+          <ProfileDropdown username="" /> 
+        </header>
+
+        <main className="w-full max-w-4xl mx-auto px-4 pt-5 pb-32 space-y-5">
+          {/* Display the pixel-perfect skeleton! */}
+          <DashboardSkeleton />
+        </main>
+
+        <BottomNav />
+      </div>
+    </div>
+  );
+}

--- a/src/app/goals/loading.tsx
+++ b/src/app/goals/loading.tsx
@@ -1,0 +1,31 @@
+import BottomNav from "@/components/BottomNav";
+import { ProfileDropdown } from "@/components/ProfileDropdown";
+import { GoalsSkeleton } from "@/components/GoalsSkeleton";
+
+export default function GoalsLoading() {
+  return (
+    <div className="min-h-screen bg-neutral-950 text-neutral-100">
+      <div className="mx-auto w-full max-w-md md:max-w-7xl min-h-screen flex flex-col relative border-x border-neutral-800/60">
+
+        <header className="sticky top-0 z-10 bg-neutral-950/90 backdrop-blur-md flex items-center justify-between px-4 py-4 border-b border-neutral-800">
+          {/* Invisible spacer to replace the back arrow and keep flexbox perfectly balanced */}
+          <span className="w-10" />
+          
+          {/* Added text-center here to match the real page! */}
+          <h1 className="text-base font-semibold text-neutral-100 text-center">
+            Goals
+          </h1>
+          
+          {/* Empty string while loading user data */}
+          <ProfileDropdown username="" />
+        </header>
+
+        <main className="w-full max-w-4xl mx-auto px-4 pt-5 pb-32 space-y-5">
+          <GoalsSkeleton count={2} />
+        </main>
+
+        <BottomNav />
+      </div>
+    </div>
+  );
+}

--- a/src/app/goals/page.tsx
+++ b/src/app/goals/page.tsx
@@ -31,9 +31,7 @@ export default async function GoalsPage() {
       <div className="mx-auto w-full max-w-md md:max-w-7xl min-h-screen flex flex-col relative border-x border-neutral-800/60">
 
         <header className="sticky top-0 z-10 bg-neutral-950/90 backdrop-blur-md flex items-center justify-between px-4 py-4 border-b border-neutral-800">
-          <Link href="/dashboard" className="text-neutral-400 hover:text-neutral-200 transition-colors" aria-label="Back to dashboard">
-            <ChevronLeft className="w-5 h-5" />
-          </Link>
+          <span className="w-10" />
           <h1 className="text-base font-semibold text-neutral-100">Goals</h1>
           <ProfileDropdown username={userName} />
         </header>

--- a/src/app/log/loading.tsx
+++ b/src/app/log/loading.tsx
@@ -1,21 +1,8 @@
 import BottomNav from "@/components/BottomNav";
-import { LogClient } from "@/components/log-client";
-import { createClient } from "@/lib/supabase/server";
-import { redirect } from "next/navigation";
 import { ProfileDropdown } from "@/components/ProfileDropdown";
+import { LogSkeleton } from "@/components/LogSkeleton";
 
-export const metadata = { title: "Daily Log — SMHWT" };
-
-export default async function LogPage() {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) redirect("/login");
-
-  const userName =
-    user.user_metadata?.full_name?.split(" ")[0] ??
-    user.email?.split("@")[0] ??
-    "?";
-
+export default function LogLoading() {
   return (
     <div className="min-h-screen bg-neutral-950 text-neutral-100">
       <div className="mx-auto w-full max-w-md md:max-w-7xl min-h-screen flex flex-col relative border-x border-neutral-800/60">
@@ -23,11 +10,12 @@ export default async function LogPage() {
         <header className="sticky top-0 z-10 bg-neutral-950/90 backdrop-blur-md flex items-center justify-between px-4 py-4 border-b border-neutral-800">
           <span className="w-10" />
           <h1 className="text-base font-semibold text-neutral-100">Daily Log</h1>
-          <ProfileDropdown username={userName} />
+          <ProfileDropdown username="" />
         </header>
 
         <div className="flex-1">
-          <LogClient />
+          {/* Inject the skeleton right here! */}
+          <LogSkeleton />
         </div>
 
         <BottomNav />

--- a/src/app/profile/loading.tsx
+++ b/src/app/profile/loading.tsx
@@ -1,0 +1,23 @@
+import BottomNav from "@/components/BottomNav";
+import { ProfileSkeleton } from "@/components/ProfileSkeleton";
+
+export default function ProfileLoading() {
+  return (
+    <div className="min-h-screen bg-neutral-950 text-neutral-100">
+      <div className="mx-auto w-full max-w-md md:max-w-7xl min-h-screen flex flex-col relative border-x border-neutral-800/60">
+        <header className="sticky top-0 z-10 bg-neutral-950/90 backdrop-blur-md flex items-center justify-between px-4 py-4 border-b border-neutral-800">
+          <span className="w-10" />
+          <h1 className="text-base font-semibold text-neutral-100">Profile</h1>
+          <span className="w-10" />
+        </header>
+
+        <main className="w-full max-w-4xl mx-auto px-4 pt-5 pb-32 space-y-5">
+          {/* We pass count={2} so it doesn't take up the whole screen */}
+          <ProfileSkeleton /> 
+        </main>
+
+        <BottomNav />
+      </div>
+    </div>
+  );
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,6 +1,6 @@
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
-import { ChevronLeft, ShieldAlert } from "lucide-react";
+import { ShieldAlert } from "lucide-react";
 import Link from "next/link";
 import BottomNav from "@/components/BottomNav";
 import { ProfileForm } from "@/components/profile-form";
@@ -36,9 +36,7 @@ export default async function ProfilePage() {
       <div className="mx-auto w-full max-w-md md:max-w-7xl min-h-screen flex flex-col relative border-x border-neutral-800/60">
 
         <header className="sticky top-0 z-10 bg-neutral-950/90 backdrop-blur-md flex items-center justify-between px-4 py-4 border-b border-neutral-800">
-          <Link href="/dashboard" className="text-neutral-400 hover:text-neutral-200 transition-colors" aria-label="Back to dashboard">
-            <ChevronLeft className="w-5 h-5" />
-          </Link>
+          <span className="w-10" />
           <h1 className="text-base font-semibold text-neutral-100">Profile</h1>
           <span className="w-10" />
         </header>

--- a/src/app/resources/loading.tsx
+++ b/src/app/resources/loading.tsx
@@ -1,0 +1,26 @@
+import BottomNav from "@/components/BottomNav";
+import { ResourcesSkeleton } from "@/components/ResourcesSkeleton";
+import { ProfileDropdown } from "@/components/ProfileDropdown";
+
+export default function ResourcesLoading() {
+  return (
+    <div className="min-h-screen bg-neutral-950 text-neutral-100">
+      <div className="mx-auto w-full max-w-md md:max-w-7xl min-h-screen flex flex-col relative border-x border-neutral-800/60">
+
+        <header className="sticky top-0 z-10 bg-neutral-950/90 backdrop-blur-md flex items-center justify-between px-4 py-4 border-b border-neutral-800">
+          <span className="w-10" />
+          <h1 className="text-base font-semibold text-neutral-100">Resources</h1>
+          {/* Pass an empty string or a loading state for the username during the loading phase */}
+          <ProfileDropdown username="" />
+        </header>
+
+        <div className="flex-1">
+          {/* We pass count={5} to show a nice list of skeleton cards while the DB fetches! */}
+          <ResourcesSkeleton count={5} />
+        </div>
+
+        <BottomNav />
+      </div>
+    </div>
+  );
+}

--- a/src/app/resources/page.tsx
+++ b/src/app/resources/page.tsx
@@ -1,5 +1,3 @@
-import { ChevronLeft } from "lucide-react";
-import Link from "next/link";
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { getResources } from "@/app/actions/resources";
@@ -26,9 +24,7 @@ export default async function ResourcesPage() {
       <div className="mx-auto w-full max-w-md md:max-w-7xl min-h-screen flex flex-col relative border-x border-neutral-800/60">
 
         <header className="sticky top-0 z-10 bg-neutral-950/90 backdrop-blur-md flex items-center justify-between px-4 py-4 border-b border-neutral-800">
-          <Link href="/dashboard" className="text-neutral-400 hover:text-neutral-200 transition-colors" aria-label="Back to dashboard">
-            <ChevronLeft className="w-5 h-5" />
-          </Link>
+          <span className="w-10" />
           <h1 className="text-base font-semibold text-neutral-100">Resources</h1>
           <ProfileDropdown username={userName} />
         </header>

--- a/src/app/search/loading.tsx
+++ b/src/app/search/loading.tsx
@@ -1,35 +1,23 @@
-import { redirect } from "next/navigation";
-import { createClient } from "@/lib/supabase/server";
 import BottomNav from "@/components/BottomNav";
-import { SearchRetrieve } from "@/components/search-retrieve";
 import { ProfileDropdown } from "@/components/ProfileDropdown";
+import { SearchSkeleton } from "@/components/SearchSkeleton";
 
-export const metadata = { title: "Search — SMHWT" };
-
-export default async function SearchPage() {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) redirect("/login");
-
-  const userName =
-    user.user_metadata?.full_name?.split(" ")[0] ??
-    user.email?.split("@")[0] ??
-    "?";
-
+export default function SearchLoading() {
   return (
     <div className="min-h-screen bg-neutral-950 text-neutral-100">
       <div className="mx-auto w-full max-w-md md:max-w-7xl min-h-screen flex flex-col relative border-x border-neutral-800/60">
+        
         <header className="sticky top-0 z-10 bg-neutral-950/90 backdrop-blur-md flex items-center justify-between px-4 py-4 border-b border-neutral-800">
           <span className="w-10" />
           <h1 className="text-base font-semibold text-neutral-100">Search</h1>
-          <ProfileDropdown username={userName} />
+          {/* Empty string while loading user data */}
+          <ProfileDropdown username="" />
         </header>
 
-        <div className="flex-1">
-            <SearchRetrieve />
-        </div>
+        <main className="flex-1">
+          {/* Inject the skeleton right here! */}
+          <SearchSkeleton />
+        </main>
 
         <BottomNav />
       </div>

--- a/src/app/stories/loading.tsx
+++ b/src/app/stories/loading.tsx
@@ -1,0 +1,28 @@
+import BottomNav from "@/components/BottomNav";
+import { ProfileDropdown } from "@/components/ProfileDropdown";
+import { StoriesSkeleton } from "@/components/StoriesSkeleton";
+
+export default function StoriesLoading() {
+  return (
+    <div className="min-h-screen bg-neutral-950 text-neutral-100">
+      <div className="mx-auto w-full max-w-md md:max-w-7xl min-h-screen flex flex-col relative border-x border-neutral-800/60">
+
+        <header className="sticky top-0 z-10 bg-neutral-950/90 backdrop-blur-md flex items-center justify-between px-4 py-4 border-b border-neutral-800">
+          <span className="w-10" />
+          <h1 className="text-base font-semibold text-neutral-100 text-center">
+            Peer Stories
+          </h1>
+          {/* Empty string or placeholder while loading user data */}
+          <ProfileDropdown username="" />
+        </header>
+
+        <main className="flex-1">
+          {/* Inject the pixel-perfect skeleton! */}
+          <StoriesSkeleton count={3} />
+        </main>
+
+        <BottomNav />
+      </div>
+    </div>
+  );
+}

--- a/src/app/stories/page.tsx
+++ b/src/app/stories/page.tsx
@@ -1,10 +1,7 @@
-import { Suspense } from "react";
-import { ChevronLeft } from "lucide-react";
-import Link from "next/link";
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { getApprovedStories } from "@/app/actions/peer-stories";
-import { PeerStoriesClient, StoryFeedSkeleton } from "@/components/peer-stories-client";
+import { PeerStoriesClient } from "@/components/peer-stories-client";
 import BottomNav from "@/components/BottomNav";
 import { ProfileDropdown } from "@/components/ProfileDropdown";
 
@@ -17,7 +14,9 @@ async function StoriesFeed() {
 
 export default async function StoriesPage() {
   const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
   if (!user) redirect("/login");
 
   const userName =
@@ -28,23 +27,16 @@ export default async function StoriesPage() {
   return (
     <div className="min-h-screen bg-neutral-950 text-neutral-100">
       <div className="mx-auto w-full max-w-md md:max-w-7xl min-h-screen flex flex-col relative border-x border-neutral-800/60">
-
         <header className="sticky top-0 z-10 bg-neutral-950/90 backdrop-blur-md flex items-center justify-between px-4 py-4 border-b border-neutral-800">
-          <Link href="/dashboard" className="text-neutral-400 hover:text-neutral-200 transition-colors" aria-label="Back to dashboard">
-            <ChevronLeft className="w-5 h-5" />
-          </Link>
-          <h1 className="text-base font-semibold text-neutral-100">Peer Stories</h1>
+          <span className="w-10" />
+          <h1 className="text-base font-semibold text-neutral-100">
+            Peer Stories
+          </h1>
           <ProfileDropdown username={userName} />
         </header>
 
         <div className="flex-1">
-          <Suspense fallback={
-            <div className="px-4 pt-5 pb-32 space-y-3">
-              <StoryFeedSkeleton />
-            </div>
-          }>
             <StoriesFeed />
-          </Suspense>
         </div>
 
         <BottomNav />

--- a/src/components/DashboardSkeleton.tsx
+++ b/src/components/DashboardSkeleton.tsx
@@ -1,0 +1,68 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function DashboardSkeleton() {
+  return (
+    <div className="space-y-5 animate-in fade-in duration-500">
+      
+      {/* ── Dashboard Summary Card ── */}
+      <div className="bg-[#1a1a1a] border border-neutral-800 rounded-xl overflow-hidden">
+        
+        {/* Greeting Header */}
+        <div className="px-5 pt-5 pb-4 border-b border-neutral-800 space-y-2.5">
+          <Skeleton className="h-3 w-32 bg-neutral-800" /> {/* Date */}
+          <Skeleton className="h-5 w-48 bg-neutral-800" /> {/* Greeting */}
+          <Skeleton className="h-3 w-40 bg-neutral-800" /> {/* Streak text */}
+        </div>
+
+        {/* Stat Cards (Grid) */}
+        <div className="grid grid-cols-3 divide-x divide-neutral-800 border-b border-neutral-800">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="px-4 py-3 flex flex-col gap-1.5">
+              <Skeleton className="h-2 w-12 bg-neutral-800" /> {/* Label */}
+              <Skeleton className="h-6 w-10 bg-neutral-800" /> {/* Big Number */}
+              <Skeleton className="h-2 w-16 bg-neutral-800" /> {/* Sub-label */}
+            </div>
+          ))}
+        </div>
+
+        {/* Mood Trend Chart */}
+        <div className="px-5 pt-4 pb-3 border-b border-neutral-800">
+          <div className="flex items-center justify-between mb-3">
+            <Skeleton className="h-3 w-20 bg-neutral-800" /> {/* "Mood trend" */}
+            <Skeleton className="h-2 w-16 bg-neutral-800" /> {/* "Last 7 days" */}
+          </div>
+          <Skeleton className="h-14 w-full rounded-md bg-neutral-800" /> {/* Chart Area */}
+        </div>
+
+        {/* Recent Journal Entries */}
+        <div className="px-5 pt-4 pb-5">
+          <Skeleton className="h-3 w-28 bg-neutral-800 mb-4" /> {/* "Recent entries" */}
+          
+          <div className="flex flex-col gap-2">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div
+                key={i}
+                className="flex items-start gap-3 py-2 border-b border-neutral-800 last:border-b-0"
+              >
+                <Skeleton className="w-1.5 h-1.5 rounded-full bg-neutral-700 mt-1.5 shrink-0" /> {/* Blue dot */}
+                <div className="flex-1 space-y-2">
+                  <Skeleton className="h-4 w-3/4 bg-neutral-800" /> {/* Title */}
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <Skeleton className="h-3 w-24 bg-neutral-800" /> {/* Date text */}
+                    <Skeleton className="h-4 w-12 rounded-full bg-neutral-800" /> {/* Tag 1 */}
+                    <Skeleton className="h-4 w-16 rounded-full bg-neutral-800" /> {/* Tag 2 */}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+      </div>
+
+      {/* ── Browse Resources Button ── */}
+      <Skeleton className="h-14 w-full rounded-xl bg-neutral-900 border border-neutral-800" />
+
+    </div>
+  );
+}

--- a/src/components/GoalsSkeleton.tsx
+++ b/src/components/GoalsSkeleton.tsx
@@ -1,0 +1,67 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function GoalsSkeleton({ count = 2 }: { count?: number }) {
+  return (
+    <div className="w-full max-w-4xl mx-auto pt-5 pb-32 space-y-5 animate-in fade-in duration-500">
+      
+      {/* ── Wellness Goal Form Skeleton ── */}
+      <section>
+        <div className="bg-[#1a1a1a] border border-neutral-800 rounded-xl p-6 space-y-4">
+          <Skeleton className="h-6 w-40 bg-neutral-800 mb-2" /> {/* Title */}
+          
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-56 bg-neutral-800" /> {/* Label */}
+            <Skeleton className="h-24 w-full rounded-lg bg-neutral-900 border border-neutral-800" /> {/* Textarea */}
+          </div>
+
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-32 bg-neutral-800" /> {/* Label */}
+            <Skeleton className="h-12 w-full rounded-lg bg-neutral-900 border border-neutral-800" /> {/* Date Input */}
+          </div>
+
+          <Skeleton className="h-12 w-full rounded-lg bg-neutral-800 mt-2" /> {/* Submit Button */}
+        </div>
+      </section>
+
+      {/* ── Active Goals Section Skeleton ── */}
+      <section className="space-y-4">
+        {/* Section Header (Title + Count Badge) */}
+        <h2 className="flex items-center gap-2">
+          <Skeleton className="h-5 w-16 bg-neutral-800" />
+          <Skeleton className="h-5 w-6 rounded-full bg-neutral-800" />
+        </h2>
+        
+        {/* Goal Cards Grid */}
+        <div className="grid gap-4">
+          {Array.from({ length: count }).map((_, i) => (
+            <div 
+              key={i} 
+              className="bg-[#1a1a1a] border border-neutral-800 rounded-xl p-5 flex flex-col gap-4"
+            >
+              {/* Header Row (Status Badge) */}
+              <div className="flex justify-between items-start">
+                <Skeleton className="h-6 w-20 rounded-full bg-neutral-800" />
+              </div>
+
+              {/* Goal Body */}
+              <div className="space-y-2">
+                <Skeleton className="h-4 w-full bg-neutral-800" />
+                <Skeleton className="h-4 w-4/5 bg-neutral-800" />
+              </div>
+
+              {/* Date */}
+              <Skeleton className="h-3 w-32 bg-neutral-800" />
+
+              {/* Actions (Transitions) */}
+              <div className="flex gap-2 mt-2 pt-4 border-t border-neutral-800">
+                <Skeleton className="h-9 flex-1 rounded-lg bg-neutral-800" />
+                <Skeleton className="h-9 flex-1 rounded-lg bg-neutral-800" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+    </div>
+  );
+}

--- a/src/components/LogSkeleton.tsx
+++ b/src/components/LogSkeleton.tsx
@@ -1,0 +1,155 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function LogSkeleton() {
+  return (
+    <div className="w-full max-w-4xl mx-auto px-4 pt-5 pb-32 animate-in fade-in duration-500">
+      
+      {/* ── Tab Switcher ── */}
+      <div className="flex bg-neutral-900/50 p-1 rounded-lg mb-8 border border-neutral-800">
+        <Skeleton className="h-9 flex-1 rounded-md bg-neutral-800" />
+        <Skeleton className="h-9 flex-1 rounded-md bg-transparent" />
+      </div>
+
+      <div className="w-full space-y-8">
+        
+        {/* ── TOP PART (Narrow: Centered Calendar & Widget) ── */}
+        <div className="w-full max-w-md mx-auto space-y-8">
+          
+          <section>
+            <div className="flex items-center justify-between mb-3">
+              <Skeleton className="w-7 h-7 rounded-lg bg-neutral-800" />
+              <Skeleton className="h-4 w-28 bg-neutral-800" />
+              <Skeleton className="w-7 h-7 rounded-lg bg-neutral-800" />
+            </div>
+            <div className="grid grid-cols-7 mb-1 gap-1">
+              {Array.from({ length: 7 }).map((_, i) => (
+                <Skeleton key={`dh-${i}`} className="h-3 w-4 mx-auto bg-neutral-800" />
+              ))}
+            </div>
+            <div className="grid grid-cols-7 gap-1">
+              {Array.from({ length: 35 }).map((_, i) => (
+                <Skeleton key={`d-${i}`} className="h-8 w-full rounded-lg bg-neutral-800" />
+              ))}
+            </div>
+          </section>
+
+          <section>
+            <Skeleton className="h-3 w-40 bg-neutral-800 mb-3" />
+            <div className="flex gap-2 justify-between">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <Skeleton key={`em-${i}`} className="flex-1 h-16 rounded-xl bg-neutral-800" />
+              ))}
+            </div>
+          </section>
+
+          <section>
+            <Skeleton className="h-3 w-24 bg-neutral-800 mb-2" />
+            <Skeleton className="h-2 w-full rounded-full bg-neutral-800 my-3" />
+            <div className="flex justify-between mt-1">
+              <Skeleton className="h-2 w-16 bg-neutral-800" />
+              <Skeleton className="h-2 w-16 bg-neutral-800" />
+            </div>
+          </section>
+        </div>
+
+        {/* ── BOTTOM PART (Full-Width Form with Single Boxes) ── */}
+        <div className="w-full space-y-8 pt-4">
+          
+          {/* Sleep Quality (Now a single box instead of multiple side-by-side) */}
+          <section className="space-y-3">
+            <Skeleton className="h-3 w-28 bg-neutral-800" /> 
+            <Skeleton className="h-11 w-full rounded-lg bg-neutral-900 border border-neutral-800" />
+          </section>
+
+          {/* Textarea Note */}
+          <section className="space-y-3">
+             <Skeleton className="h-3 w-48 bg-neutral-800" />
+             <Skeleton className="h-24 w-full rounded-xl bg-neutral-900 border border-neutral-800" />
+          </section>
+
+          {/* Academic Impact */}
+          <section className="space-y-3">
+             <Skeleton className="h-3 w-32 bg-neutral-800" />
+             <Skeleton className="h-11 w-full rounded-lg bg-neutral-900 border border-neutral-800" />
+          </section>
+
+          {/* Taxonomy Tags Mapping */}
+          <section className="space-y-8">
+            
+            {/* Stressors Section */}
+            <div>
+              <Skeleton className="h-5 w-32 bg-neutral-800 mb-4" /> {/* "Stressors" header */}
+              <div className="space-y-5">
+                {/* Academic */}
+                <div className="space-y-3">
+                  <Skeleton className="h-2 w-20 bg-neutral-800" />
+                  <div className="flex flex-wrap gap-2">
+                    <Skeleton className="h-7 w-24 rounded-full bg-neutral-800" />
+                    <Skeleton className="h-7 w-28 rounded-full bg-neutral-800" />
+                    <Skeleton className="h-7 w-20 rounded-full bg-neutral-800" />
+                    <Skeleton className="h-7 w-32 rounded-full bg-neutral-800" />
+                    <Skeleton className="h-7 w-24 rounded-full bg-neutral-800" />
+                  </div>
+                </div>
+
+                {/* Social */}
+                <div className="space-y-3">
+                  <Skeleton className="h-2 w-16 bg-neutral-800" />
+                  <div className="flex flex-wrap gap-2">
+                    <Skeleton className="h-7 w-20 rounded-full bg-neutral-800" />
+                    <Skeleton className="h-7 w-24 rounded-full bg-neutral-800" />
+                    <Skeleton className="h-7 w-16 rounded-full bg-neutral-800" />
+                  </div>
+                </div>
+
+                {/* Personal */}
+                <div className="space-y-3">
+                  <Skeleton className="h-2 w-20 bg-neutral-800" />
+                  <div className="flex flex-wrap gap-2">
+                    <Skeleton className="h-7 w-28 rounded-full bg-neutral-800" />
+                    <Skeleton className="h-7 w-24 rounded-full bg-neutral-800" />
+                    <Skeleton className="h-7 w-20 rounded-full bg-neutral-800" />
+                    <Skeleton className="h-7 w-16 rounded-full bg-neutral-800" />
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {/* Coping Strategies Section */}
+            <div>
+              <Skeleton className="h-5 w-40 bg-neutral-800 mb-4" /> {/* "Coping Strategies" header */}
+              <div className="space-y-5">
+                {/* Healthy */}
+                <div className="space-y-3">
+                  <Skeleton className="h-2 w-20 bg-neutral-800" />
+                  <div className="flex flex-wrap gap-2">
+                    <Skeleton className="h-7 w-24 rounded-full bg-neutral-800" />
+                    <Skeleton className="h-7 w-32 rounded-full bg-neutral-800" />
+                    <Skeleton className="h-7 w-20 rounded-full bg-neutral-800" />
+                    <Skeleton className="h-7 w-28 rounded-full bg-neutral-800" />
+                    <Skeleton className="h-7 w-24 rounded-full bg-neutral-800" />
+                  </div>
+                </div>
+
+                {/* Avoidant */}
+                <div className="space-y-3">
+                  <Skeleton className="h-2 w-24 bg-neutral-800" />
+                  <div className="flex flex-wrap gap-2">
+                    <Skeleton className="h-7 w-24 rounded-full bg-neutral-800" />
+                    <Skeleton className="h-7 w-20 rounded-full bg-neutral-800" />
+                    <Skeleton className="h-7 w-28 rounded-full bg-neutral-800" />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          {/* Submit Button */}
+          <Skeleton className="h-12 w-full rounded-xl bg-neutral-800 mt-6" />
+
+        </div>
+      </div>
+
+    </div>
+  );
+}

--- a/src/components/ProfileSkeleton.tsx
+++ b/src/components/ProfileSkeleton.tsx
@@ -1,0 +1,48 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function ProfileSkeleton() {
+  return (
+    <div className="space-y-5 animate-in fade-in duration-500">
+      {/* ── Avatar ── */}
+      <section className="flex flex-col items-center gap-3 pt-2">
+        <Skeleton className="w-16 h-16 rounded-full bg-neutral-800" />
+        <div className="flex flex-col items-center gap-2">
+          <Skeleton className="h-4 w-32 bg-neutral-800" />
+          <Skeleton className="h-3 w-48 bg-neutral-800" />
+        </div>
+      </section>
+
+      {/* ── Account info ── */}
+      <section className="space-y-3">
+        <Skeleton className="h-3 w-20 bg-neutral-800" /> {/* Section Label */}
+        <div className="bg-neutral-900 border border-neutral-800 rounded-xl px-4 py-4 space-y-4">
+          <div className="flex justify-between items-center">
+            <Skeleton className="h-3 w-12 bg-neutral-800" />
+            <Skeleton className="h-3 w-32 bg-neutral-800" />
+          </div>
+          <div className="border-t border-neutral-800" />
+          <div className="flex justify-between items-center">
+            <Skeleton className="h-3 w-16 bg-neutral-800" />
+            <Skeleton className="h-3 w-40 bg-neutral-800" />
+          </div>
+        </div>
+      </section>
+
+      {/* ── Form (Display Name / Password) ── */}
+      <section className="space-y-3">
+        <Skeleton className="h-3 w-28 bg-neutral-800" />
+        <div className="bg-neutral-900 border border-neutral-800 rounded-xl px-4 py-4 space-y-3">
+          <Skeleton className="h-4 w-20 bg-neutral-800" /> {/* Input label */}
+          <Skeleton className="h-10 w-full rounded-md bg-neutral-800" /> {/* Input field */}
+          <Skeleton className="h-10 w-24 rounded-md bg-neutral-800 mt-2" /> {/* Submit button */}
+        </div>
+      </section>
+
+      {/* ── Single Buttons (Session / Danger) ── */}
+      <section className="space-y-3">
+        <Skeleton className="h-3 w-24 bg-neutral-800" />
+        <Skeleton className="h-12 w-full rounded-xl bg-neutral-800" />
+      </section>
+    </div>
+  );
+}

--- a/src/components/ResourcesSkeleton.tsx
+++ b/src/components/ResourcesSkeleton.tsx
@@ -1,0 +1,79 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function ResourcesSkeleton({ count = 4 }: { count?: number }) {
+  return (
+    // Note: The main wrapper exactly matches the classes from resource-library.tsx
+    <main className="w-full max-w-4xl mx-auto px-4 pt-5 pb-32 space-y-6 animate-in fade-in duration-500">
+      
+      {/* ── Search Input ── */}
+      <div className="relative">
+        <Skeleton className="h-10 w-full rounded-md bg-neutral-800" />
+      </div>
+
+      {/* ── Coping Tag Filters ── */}
+      <section aria-label="Loading filters">
+        {/* "Filter by coping strategy" label */}
+        <Skeleton className="h-3 w-40 bg-neutral-800 mb-3" /> 
+
+        {/* "All" button */}
+        <div className="mb-4">
+          <Skeleton className="h-7 w-12 rounded-full bg-neutral-800" />
+        </div>
+
+        {/* Simulated COPING_TAG_GROUPS */}
+        <div className="space-y-4">
+          
+          {/* Group 1 */}
+          <div className="space-y-2">
+            <Skeleton className="h-2 w-24 bg-neutral-800" /> {/* Category Title */}
+            <div className="flex flex-wrap gap-2">
+              <Skeleton className="h-7 w-20 rounded-full bg-neutral-800" />
+              <Skeleton className="h-7 w-28 rounded-full bg-neutral-800" />
+              <Skeleton className="h-7 w-16 rounded-full bg-neutral-800" />
+            </div>
+          </div>
+          
+          {/* Group 2 */}
+          <div className="space-y-2">
+            <Skeleton className="h-2 w-32 bg-neutral-800" /> {/* Category Title */}
+            <div className="flex flex-wrap gap-2">
+              <Skeleton className="h-7 w-24 rounded-full bg-neutral-800" />
+              <Skeleton className="h-7 w-16 rounded-full bg-neutral-800" />
+              <Skeleton className="h-7 w-32 rounded-full bg-neutral-800" />
+              <Skeleton className="h-7 w-20 rounded-full bg-neutral-800" />
+            </div>
+          </div>
+
+        </div>
+      </section>
+
+      {/* ── Results ── */}
+      <section aria-label="Loading results">
+        {/* "X resources" label */}
+        <Skeleton className="h-3 w-24 bg-neutral-800 mb-3" /> 
+
+        <div className="space-y-3">
+          {Array.from({ length: count }).map((_, i) => (
+            <Card key={i} className="bg-neutral-900 border-neutral-800">
+              <CardContent className="pt-4 pb-4 space-y-3">
+                <div className="flex items-start justify-between gap-3">
+                  {/* Title */}
+                  <Skeleton className="h-4 w-3/4 bg-neutral-800" />
+                  {/* External Link Icon placeholder */}
+                  <Skeleton className="h-4 w-4 bg-neutral-800 shrink-0" />
+                </div>
+                
+                {/* Tags row */}
+                <div className="flex flex-wrap gap-1.5 pt-1">
+                  <Skeleton className="h-4 w-14 rounded-sm bg-neutral-800" />
+                  <Skeleton className="h-4 w-20 rounded-sm bg-neutral-800" />
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/components/SearchSkeleton.tsx
+++ b/src/components/SearchSkeleton.tsx
@@ -1,0 +1,40 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function SearchSkeleton() {
+  return (
+    <div className="w-full max-w-4xl mx-auto px-4 pt-5 pb-32 animate-in fade-in duration-500">
+      
+      {/* ── Search Input Mock ── */}
+      <Skeleton className="h-12 w-full rounded-xl bg-neutral-900 border border-neutral-800 mb-4" />
+
+      {/* ── All Tags Filter Mock (Smaller and More Dense) ── */}
+      <div className="flex flex-wrap gap-2 mb-8">
+        <Skeleton className="h-6 w-16 rounded-full bg-neutral-800" />
+        <Skeleton className="h-6 w-20 rounded-full bg-neutral-800" />
+        <Skeleton className="h-6 w-14 rounded-full bg-neutral-800" />
+        <Skeleton className="h-6 w-24 rounded-full bg-neutral-800" />
+        <Skeleton className="h-6 w-16 rounded-full bg-neutral-800" />
+        <Skeleton className="h-6 w-20 rounded-full bg-neutral-800" />
+        <Skeleton className="h-6 w-28 rounded-full bg-neutral-800" />
+        <Skeleton className="h-6 w-14 rounded-full bg-neutral-800" />
+        <Skeleton className="h-6 w-24 rounded-full bg-neutral-800" />
+        <Skeleton className="h-6 w-16 rounded-full bg-neutral-800" />
+        <Skeleton className="h-6 w-20 rounded-full bg-neutral-800" />
+        <Skeleton className="h-6 w-14 rounded-full bg-neutral-800" />
+        <Skeleton className="h-6 w-24 rounded-full bg-neutral-800" />
+        <Skeleton className="h-6 w-16 rounded-full bg-neutral-800" />
+        <Skeleton className="h-6 w-20 rounded-full bg-neutral-800" />
+        <Skeleton className="h-6 w-32 rounded-full bg-neutral-800" />
+        <Skeleton className="h-6 w-14 rounded-full bg-neutral-800" />
+        <Skeleton className="h-6 w-20 rounded-full bg-neutral-800" />
+      </div>
+
+      {/* ── Idle State Placeholder ── */}
+      <div className="flex flex-col items-center gap-3 py-20">
+        <Skeleton className="w-10 h-10 rounded-full bg-neutral-800/50" /> {/* Search Icon Mock */}
+        <Skeleton className="h-4 w-64 bg-neutral-800/50" /> {/* "Enter a keyword..." text mock */}
+      </div>
+
+    </div>
+  );
+}

--- a/src/components/StoriesSkeleton.tsx
+++ b/src/components/StoriesSkeleton.tsx
@@ -1,0 +1,79 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function StoriesSkeleton({ count = 3 }: { count?: number }) {
+  return (
+    <div className="w-full max-w-4xl mx-auto px-4 pt-5 pb-32 space-y-6 animate-in fade-in duration-500">
+      
+      {/* ── Share Story Accordion Mock ── */}
+      <Skeleton className="h-14 w-full rounded-xl bg-neutral-900 border border-neutral-800" />
+
+      {/* ── Topic Filters (FORUM_TAG_GROUPS Mock) ── */}
+      <section className="space-y-4">
+        <Skeleton className="h-4 w-32 bg-neutral-800 mb-3" /> {/* "Filter by topic" label */}
+        
+        {/* Category 1 */}
+        <div className="space-y-3">
+          <Skeleton className="h-2 w-24 bg-neutral-800" />
+          <div className="flex flex-wrap gap-2">
+            <Skeleton className="h-7 w-20 rounded-full bg-neutral-800" />
+            <Skeleton className="h-7 w-24 rounded-full bg-neutral-800" />
+            <Skeleton className="h-7 w-16 rounded-full bg-neutral-800" />
+            <Skeleton className="h-7 w-28 rounded-full bg-neutral-800" />
+          </div>
+        </div>
+
+        {/* Category 2 */}
+        <div className="space-y-3">
+          <Skeleton className="h-2 w-20 bg-neutral-800" />
+          <div className="flex flex-wrap gap-2">
+            <Skeleton className="h-7 w-28 rounded-full bg-neutral-800" />
+            <Skeleton className="h-7 w-16 rounded-full bg-neutral-800" />
+            <Skeleton className="h-7 w-24 rounded-full bg-neutral-800" />
+          </div>
+        </div>
+      </section>
+
+      {/* ── Results Count & Sort Dropdown ── */}
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-4 w-24 bg-neutral-800" /> {/* "X stories" */}
+        <Skeleton className="h-8 w-24 rounded-lg bg-neutral-800" /> {/* Sort Dropdown */}
+      </div>
+
+      {/* ── Anonymous Story Cards ── */}
+      <div className="space-y-4">
+        {Array.from({ length: count }).map((_, i) => (
+          <Card key={i} className="bg-[#1a1a1a] border-neutral-800">
+            <CardContent className="pt-5 pb-5 space-y-4">
+              
+              {/* Header: Title + Author/Date */}
+              <div className="space-y-2">
+                <Skeleton className="h-5 w-3/4 bg-neutral-800" />
+                <div className="flex items-center gap-2">
+                  <Skeleton className="h-3 w-3 rounded-full bg-neutral-800 shrink-0" /> {/* Shield Icon Mock */}
+                  <Skeleton className="h-3 w-40 bg-neutral-800" /> {/* "Anonymous Student · Date" */}
+                </div>
+              </div>
+
+              {/* Tags Row */}
+              <div className="flex flex-wrap gap-1.5">
+                <Skeleton className="h-5 w-16 rounded-md bg-neutral-800" />
+                <Skeleton className="h-5 w-20 rounded-md bg-neutral-800" />
+                <Skeleton className="h-5 w-14 rounded-md bg-neutral-800" />
+              </div>
+
+              {/* Body Text */}
+              <div className="space-y-2 pt-2">
+                <Skeleton className="h-4 w-full bg-neutral-800" />
+                <Skeleton className="h-4 w-full bg-neutral-800" />
+                <Skeleton className="h-4 w-4/5 bg-neutral-800" />
+              </div>
+              
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+    </div>
+  );
+}

--- a/src/components/peer-stories-client.tsx
+++ b/src/components/peer-stories-client.tsx
@@ -4,7 +4,6 @@ import { useState } from "react";
 import { BookHeart, ShieldCheck, ChevronDown, ChevronUp } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
-import { Skeleton } from "@/components/ui/skeleton";
 import { PeerStoryForm } from "@/components/peer-story-form";
 import type { PeerStory } from "@/app/actions/peer-stories";
 import { FORUM_TAG_GROUPS } from "@/lib/constants/tags";
@@ -30,29 +29,6 @@ function formatDate(iso: string) {
 interface Props {
   initialStories: PeerStory[];
   fetchError: string | null;
-}
-
-export function StoryFeedSkeleton() {
-  return (
-    <div className="space-y-3">
-      {Array.from({ length: 3 }).map((_, i) => (
-        <Card key={i} className="bg-neutral-900 border-neutral-800">
-          <CardContent className="pt-4 pb-4 space-y-3">
-            <Skeleton className="h-3 w-20 bg-neutral-800" />
-            <Skeleton className="h-4 w-3/4 bg-neutral-800" />
-            <Skeleton className="h-3 w-full bg-neutral-800" />
-            <Skeleton className="h-3 w-full bg-neutral-800" />
-            <Skeleton className="h-3 w-2/3 bg-neutral-800" />
-            <div className="flex gap-2 pt-1 border-t border-neutral-800">
-              <Skeleton className="h-3 w-16 bg-neutral-800" />
-              <Skeleton className="h-3 w-12 bg-neutral-800" />
-              <Skeleton className="h-3 w-12 bg-neutral-800" />
-            </div>
-          </CardContent>
-        </Card>
-      ))}
-    </div>
-  );
 }
 
 function StoryCard({ story }: { story: PeerStory }) {


### PR DESCRIPTION
## What Changed
- Added dedicated skeleton UI components for all pages, each close to their respective page layouts
- Removed hardcoded StoryFeedSkeleton from `peer-stories-client.tsx`
- Added `loading.tsx` for each routed page to leverage Nextjs loading states
- Removed the dashboard back arrow for all `page.tsx` and `loading.tsx` except the Admin panel's, which redirects back to profile

## Checklist
- [x] Forked from dev
- [x] App runs without errors
- [x] No .env files committed
- [x] No console.log in code