### PR TITLE
feat: Implement pg_trgm fuzzy search and query normalization

### DIFF
--- a/src/app/actions/search.ts
+++ b/src/app/actions/search.ts
@@ -32,9 +32,13 @@ export type SearchResults = {
 };
 
 /**
- * Fetches journal entries and resources matching the keyword.
- * Tag filtering is handled client-side for guaranteed AND correctness.
- * Pattern summary uses the first selected tag passed separately.
+ * Unified fuzzy search across journal_entries and resources.
+ *
+ * Uses pg_trgm Postgres RPCs for case-insensitive, punctuation-tolerant,
+ * and fuzzy keyword matching at the database level. Tag filtering and
+ * pattern summary are handled after the DB fetch.
+ *
+ * Data shape is unchanged — search-retrieve.tsx client filtering works as-is.
  */
 export async function searchAll(
   keyword: string,
@@ -43,97 +47,62 @@ export async function searchAll(
   try {
     const supabase = await createClient();
 
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return { journals: [], resources: [], pattern: null, error: "Not authenticated." };
+
+    const trimmed = keyword.trim();
+
     // ── Journal entries ────────────────────────────────────────────────────
-    let journalQuery = supabase
-      .from("journal_entries")
-      .select("id, title, body, tags, created_at")
-      .order("created_at", { ascending: false })
-      .limit(50);
+    let journals: JournalResult[] = [];
 
-    if (keyword) {
-      // 1. Remove double quotes to protect the parser
-      const cleanKw = keyword.replace(/"/g, '');
-      
-      const straightKw = cleanKw.replace(/’/g, "'");
-      const curlyKw = cleanKw.replace(/'/g, '’');
-
-      // 2. The "Smart Dictionary" Fix: Auto-inject apostrophes for common words
-      // (\b means "word boundary", so it won't accidentally turn "swim" into "swi'm")
-      const smartStraight = straightKw
-        .replace(/\bim\b/gi, "i'm")
-        .replace(/\bcant\b/gi, "can't")
-        .replace(/\bdont\b/gi, "don't")
-        .replace(/\bive\b/gi, "i've")
-        .replace(/\bthats\b/gi, "that's")
-        .replace(/\bwhats\b/gi, "what's")
-        .replace(/\bwasnt\b/gi, "wasn't");
-
-      const smartCurly = curlyKw
-        .replace(/\bim\b/gi, "i’m")
-        .replace(/\bcant\b/gi, "can’t")
-        .replace(/\bdont\b/gi, "don’t")
-        .replace(/\bive\b/gi, "i’ve")
-        .replace(/\bthats\b/gi, "that’s")
-        .replace(/\bwhats\b/gi, "what’s")
-        .replace(/\bwasnt\b/gi, "wasn’t");
-
-      // 3. Put all variations into a Set (which automatically removes any duplicates)
-      const variations = Array.from(new Set([cleanKw, straightKw, curlyKw, smartStraight, smartCurly]));
-
-      // 4. Build the Supabase .or() string dynamically!
-      const orQuery = variations.map((v) => `title.ilike."%${v}%"`).join(',');
-      
-      journalQuery = journalQuery.or(orQuery);
+    if (trimmed) {
+      const { data, error } = await supabase.rpc("search_journal_entries", {
+        p_keyword: trimmed,
+        p_user_id: user.id,
+        p_limit:   50,
+      });
+      if (error) throw error;
+      journals = (data ?? []) as JournalResult[];
+    } else {
+      // No keyword — fetch all user journals so tag-only filtering still works
+      const { data, error } = await supabase
+        .from("journal_entries")
+        .select("id, title, body, tags, created_at")
+        .eq("user_id", user.id)
+        .order("created_at", { ascending: false })
+        .limit(50);
+      if (error) throw error;
+      journals = (data ?? []) as JournalResult[];
     }
-
-    const { data: journals, error: jError } = await journalQuery;
-    if (jError) throw jError;
 
     // ── Resources ──────────────────────────────────────────────────────────
-    let resourceQuery = supabase
-      .from("resources")
-      .select("id, title, url, tags")
-      .limit(50);
+    let resources: ResourceResult[] = [];
 
-    if (keyword) {
-      const cleanKw = keyword.replace(/"/g, '');
-      const straightKw = cleanKw.replace(/’/g, "'");
-      const curlyKw = cleanKw.replace(/'/g, '’');
-
-      const smartStraight = straightKw
-        .replace(/\bim\b/gi, "i'm")
-        .replace(/\bcant\b/gi, "can't")
-        .replace(/\bdont\b/gi, "don't")
-        .replace(/\bive\b/gi, "i've")
-        .replace(/\bthats\b/gi, "that's")
-        .replace(/\bwhats\b/gi, "what's")
-        .replace(/\bwasnt\b/gi, "wasn't");
-
-      const smartCurly = curlyKw
-        .replace(/\bim\b/gi, "i’m")
-        .replace(/\bcant\b/gi, "can’t")
-        .replace(/\bdont\b/gi, "don’t")
-        .replace(/\bive\b/gi, "i’ve")
-        .replace(/\bthats\b/gi, "that’s")
-        .replace(/\bwhats\b/gi, "what’s")
-        .replace(/\bwasnt\b/gi, "wasn’t");
-
-      const variations = Array.from(new Set([cleanKw, straightKw, curlyKw, smartStraight, smartCurly]));
-      const orQuery = variations.map((v) => `title.ilike."%${v}%"`).join(',');
-      
-      resourceQuery = resourceQuery.or(orQuery);
+    if (trimmed) {
+      const { data, error } = await supabase.rpc("search_resources", {
+        p_keyword: trimmed,
+        p_limit:   50,
+      });
+      if (error) throw error;
+      resources = (data ?? []) as ResourceResult[];
+    } else {
+      const { data, error } = await supabase
+        .from("resources")
+        .select("id, title, url, tags")
+        .order("created_at", { ascending: false })
+        .limit(50);
+      if (error) throw error;
+      resources = (data ?? []) as ResourceResult[];
     }
 
-    const { data: resources, error: rError } = await resourceQuery;
-    if (rError) throw rError;
-
-    // ── Pattern Summary ────────────────────────────────────────────────────
+    // ── KM Pattern Summary ─────────────────────────────────────────────────
     let pattern: PatternSummary | null = null;
-    
+
     if (patternTag) {
       const { data: taggedJournals } = await supabase
         .from("journal_entries")
         .select("created_at")
+        .eq("user_id", user.id)
         .contains("tags", [patternTag]);
 
       if (taggedJournals && taggedJournals.length > 0) {
@@ -146,6 +115,7 @@ export async function searchAll(
         const { data: moodRange } = await supabase
           .from("mood_logs")
           .select("mood_score, sleep_quality, logged_at")
+          .eq("user_id", user.id)
           .gte("logged_at", minDate)
           .lte("logged_at", maxDate + "T23:59:59Z");
 
@@ -154,12 +124,8 @@ export async function searchAll(
         );
 
         if (matched.length > 0) {
-          const moodScores = matched
-            .map((m) => m.mood_score)
-            .filter((s): s is number => s !== null);
-          const sleepScores = matched
-            .map((m) => m.sleep_quality)
-            .filter((s): s is number => s !== null);
+          const moodScores  = matched.map((m) => m.mood_score).filter((s): s is number => s !== null);
+          const sleepScores = matched.map((m) => m.sleep_quality).filter((s): s is number => s !== null);
 
           pattern = {
             tag: patternTag,
@@ -177,20 +143,10 @@ export async function searchAll(
       }
     }
 
-    return {
-      journals: journals ?? [],
-      resources: resources ?? [],
-      pattern,
-      error: null,
-    };
+    return { journals, resources, pattern, error: null };
 
   } catch (error: unknown) {
-    console.error("Search API Error:", error instanceof Error ? error.message : error);
-    return {
-      journals: [],
-      resources: [],
-      pattern: null,
-      error: "Failed to perform search. Please try again.",
-    };
+    console.error("Search error:", error instanceof Error ? error.message : error);
+    return { journals: [], resources: [], pattern: null, error: "Search failed. Please try again." };
   }
 }

--- a/supabase/migrations/search-pg-trgm.sql
+++ b/supabase/migrations/search-pg-trgm.sql
@@ -1,0 +1,142 @@
+-- ============================================================
+-- Migration: pg_trgm fuzzy search for journal entries and resources
+-- Sprint: S5 | Task: Polishing
+-- ============================================================
+
+-- ── Enable pg_trgm ───────────────────────────────────────────
+-- Already available in Supabase — no extra setup needed.
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- ── Text normalizer ──────────────────────────────────────────
+-- Strips punctuation and special characters, lowercases, collapses spaces.
+-- IMMUTABLE so Postgres can use it in indexes.
+CREATE OR REPLACE FUNCTION normalize_text(input text)
+RETURNS text AS $$
+BEGIN
+  RETURN trim(
+    regexp_replace(
+      lower(input),
+      '[^a-z0-9\s]', '', 'g'
+    )
+  );
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+-- ── GIN indexes for fast trigram search ──────────────────────
+CREATE INDEX IF NOT EXISTS idx_journal_entries_title_trgm
+  ON journal_entries USING GIN (normalize_text(title) gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS idx_journal_entries_body_trgm
+  ON journal_entries USING GIN (normalize_text(body) gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS idx_resources_title_trgm
+  ON resources USING GIN (normalize_text(title) gin_trgm_ops);
+
+-- ── Journal search RPC ────────────────────────────────────────
+-- Normalizes both the search term and stored text before comparing.
+-- Uses ILIKE for substring match + similarity() for fuzzy tolerance.
+-- SECURITY DEFINER runs as the function owner; user_id filter enforces
+-- data isolation without relying on RLS inside the function.
+CREATE OR REPLACE FUNCTION search_journal_entries(
+  p_keyword  text,
+  p_user_id  uuid,
+  p_limit    int DEFAULT 50
+)
+RETURNS TABLE(
+  id         uuid,
+  title      text,
+  body       text,
+  tags       text[],
+  created_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  norm_kw text;
+BEGIN
+  norm_kw := normalize_text(p_keyword);
+
+  RETURN QUERY
+  SELECT
+    je.id,
+    je.title,
+    je.body,
+    je.tags,
+    je.created_at
+  FROM journal_entries je
+  WHERE
+    je.user_id = p_user_id
+    AND (
+      normalize_text(je.title) ILIKE '%' || norm_kw || '%'
+      OR normalize_text(je.body)  ILIKE '%' || norm_kw || '%'
+      OR similarity(normalize_text(je.title), norm_kw) > 0.3
+      OR similarity(normalize_text(je.body),  norm_kw) > 0.3
+    )
+  ORDER BY
+    GREATEST(
+      similarity(normalize_text(je.title), norm_kw),
+      similarity(normalize_text(je.body),  norm_kw)
+    ) DESC,
+    je.created_at DESC
+  LIMIT p_limit;
+END;
+$$;
+
+-- ── Resources search RPC ──────────────────────────────────────
+-- Resources are public (authenticated read) so no user_id filter needed.
+CREATE OR REPLACE FUNCTION search_resources(
+  p_keyword text,
+  p_limit   int DEFAULT 50
+)
+RETURNS TABLE(
+  id    uuid,
+  title text,
+  url   text,
+  tags  text[]
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  norm_kw text;
+BEGIN
+  norm_kw := normalize_text(p_keyword);
+
+  RETURN QUERY
+  SELECT
+    r.id,
+    r.title,
+    r.url,
+    r.tags
+  FROM resources r
+  WHERE
+    normalize_text(r.title) ILIKE '%' || norm_kw || '%'
+    OR similarity(normalize_text(r.title), norm_kw) > 0.3
+  ORDER BY
+    similarity(normalize_text(r.title), norm_kw) DESC
+  LIMIT p_limit;
+END;
+$$;
+
+-- ── Verify ────────────────────────────────────────────────────
+SELECT 'pg_trgm active' AS check,
+       extname AS result
+FROM pg_extension WHERE extname = 'pg_trgm'
+UNION ALL
+SELECT 'normalize_text function',
+       routine_name
+FROM information_schema.routines
+WHERE routine_name = 'normalize_text'
+UNION ALL
+SELECT 'search functions',
+       COUNT(*)::text
+FROM information_schema.routines
+WHERE routine_name IN ('search_journal_entries', 'search_resources');
+
+-- Expected:
+--   pg_trgm active       | pg_trgm
+--   normalize_text       | normalize_text
+--   search functions     | 2


### PR DESCRIPTION
## What Changed
- **Database Migration:** Added the `pg_trgm` extension and a custom `normalize_text` Postgres function to automatically strip punctuation, ignore special characters, and handle case-insensitivity.
- **Performance Optimization:** Created `GIN` indexes on the normalized title and body columns for both `journal_entries` and `resources` tables to ensure lightning-fast fuzzy querying.
- **Search RPCs:** Added `search_journal_entries` and `search_resources` stored procedures to securely handle typo-tolerant, partial-word matching directly at the database level.
- **Server Action Refactor:** Rewrote the `searchAll` function in `search.ts` to consume the new Postgres RPCs, entirely replacing the legacy manual contraction mapping and rigid `ilike` logic while preserving the existing return data shape for the client.

## Checklist
- [x] Forked from dev
- [x] App runs without errors
- [x] No .env files committed
- [x] No console.log in code